### PR TITLE
Implement mount helpers and tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,27 @@
+# Developer Notes
+
+This document outlines helper utilities and how to run the unit tests while
+working on the project.
+
+## Mount helpers
+
+`ipod_sync.utils` provides small wrappers for mounting and ejecting the iPod.
+They call the system `mount`, `umount` and `eject` commands using Python's
+`subprocess` module and log any output for debugging. The helpers are:
+
+- `mount_ipod(device: str)` – mounts the given block device to the configured
+  `IPOD_MOUNT` directory.
+- `eject_ipod()` – unmounts and ejects whatever is mounted at `IPOD_MOUNT`.
+
+Both functions raise a `RuntimeError` if the underlying command fails.
+
+## Running tests
+
+The repository uses `pytest` for unit tests. Simply run:
+
+```bash
+pytest
+```
+
+The tests mock out system calls so they run quickly and without requiring an
+iPod to be attached.

--- a/ipod_sync/utils.py
+++ b/ipod_sync/utils.py
@@ -1,17 +1,65 @@
-"""Utility helpers for mounting and ejecting the iPod."""
+"""Utility helpers for mounting and ejecting the iPod.
 
+These helpers provide a small abstraction over the system ``mount`` and
+``eject`` commands. They are intentionally thin wrappers so that higher level
+modules do not need to worry about subprocess error handling or log output.
+"""
+
+from __future__ import annotations
+
+import logging
 import subprocess
 from pathlib import Path
 
 from .config import IPOD_MOUNT
 
+logger = logging.getLogger(__name__)
+
+
+def _run(cmd: list[str]) -> None:
+    """Run *cmd* via :mod:`subprocess` and raise ``RuntimeError`` on failure."""
+
+    logger.debug("Running command: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd, check=True, capture_output=True, text=True
+        )
+        if result.stdout:
+            logger.debug(result.stdout.strip())
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "Command '%s' failed with code %s: %s",
+            " ".join(cmd),
+            exc.returncode,
+            exc.stderr.strip(),
+        )
+        raise RuntimeError(
+            f"Command {' '.join(cmd)!r} failed: {exc.stderr.strip()}"
+        ) from exc
+
 
 def mount_ipod(device: str) -> None:
-    """Mount the iPod device to the configured mount point."""
-    raise NotImplementedError("mount_ipod() not yet implemented")
+    """Mount the iPod ``device`` to :data:`~ipod_sync.config.IPOD_MOUNT`.
+
+    Parameters
+    ----------
+    device:
+        The block device path (e.g. ``/dev/sda1``) representing the iPod.
+    """
+
+    mount_point: Path = IPOD_MOUNT
+    mount_point.mkdir(parents=True, exist_ok=True)
+    logger.info("Mounting %s at %s", device, mount_point)
+    _run(["mount", device, str(mount_point)])
 
 
 def eject_ipod() -> None:
-    """Eject the iPod safely."""
-    raise NotImplementedError("eject_ipod() not yet implemented")
+    """Unmount and eject the iPod currently mounted at
+    :data:`~ipod_sync.config.IPOD_MOUNT`."""
+
+    mount_point: Path = IPOD_MOUNT
+    logger.info("Unmounting %s", mount_point)
+    _run(["umount", str(mount_point)])
+    logger.info("Ejecting %s", mount_point)
+    _run(["eject", str(mount_point)])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+from unittest import mock
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ipod_sync.utils as utils
+
+
+@mock.patch("ipod_sync.utils.subprocess.run")
+def test_mount_ipod_calls_mount(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+    mount_point = tmp_path / "mnt"
+    device = "/dev/sdb1"
+    with mock.patch.object(utils, "IPOD_MOUNT", mount_point):
+        utils.mount_ipod(device)
+        mock_run.assert_called_with(
+            ["mount", device, str(mount_point)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert mount_point.exists()
+
+
+@mock.patch("ipod_sync.utils.subprocess.run")
+def test_eject_ipod_calls_umount_and_eject(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+    mount_point = tmp_path / "mnt"
+    with mock.patch.object(utils, "IPOD_MOUNT", mount_point):
+        utils.eject_ipod()
+        mock_run.assert_has_calls(
+            [
+                mock.call([
+                    "umount",
+                    str(mount_point),
+                ], check=True, capture_output=True, text=True),
+                mock.call([
+                    "eject",
+                    str(mount_point),
+                ], check=True, capture_output=True, text=True),
+            ]
+        )


### PR DESCRIPTION
## Summary
- add mount and eject utilities
- document utilities and tests in `docs/development.md`
- add unit tests for new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d31c3a7f48323834ad98ac9456b3f