### PR TITLE
Add libgpod wrapper with tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -25,3 +25,23 @@ pytest
 
 The tests mock out system calls so they run quickly and without requiring an
 iPod to be attached.
+
+## libgpod wrapper
+
+`ipod_sync.libpod_wrapper` contains helper functions that wrap the optional
+`python-gpod` bindings.  These bindings are not installed by default in the test
+environment, so the unit tests mock them out.  On a Debian based system you can
+install them via:
+
+```bash
+sudo apt-get install python3-gpod libgpod-common
+```
+
+The module exposes three simple helpers:
+
+- `add_track(path)` – import a file into the mounted iPod database.
+- `delete_track(db_id)` – remove a track by its database identifier.
+- `list_tracks()` – return a list of basic metadata for each track.
+
+If the bindings are missing a `RuntimeError` will be raised when any of these
+functions are called.

--- a/ipod_sync/libpod_wrapper.py
+++ b/ipod_sync/libpod_wrapper.py
@@ -1,19 +1,113 @@
-"""Wrapper functions for interacting with libgpod."""
+"""Wrapper helpers around the :mod:`libgpod` Python bindings.
 
+The real libgpod API is provided by the optional ``python-gpod`` package.  The
+functions in this module keep the rest of the project decoupled from the
+underlying library and make it easy to mock out libgpod in the unit tests.
+"""
+
+from __future__ import annotations
+
+import logging
 from pathlib import Path
 
+from .config import IPOD_MOUNT
 
-def add_track(filepath: Path) -> None:
-    """Add a track at *filepath* to the iPod library."""
-    raise NotImplementedError("add_track() not yet implemented")
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - the import will be mocked in tests
+    import gpod  # type: ignore
+except Exception:  # pragma: no cover - handled at runtime
+    gpod = None
+    logger.debug("python-gpod bindings not available")
+
+
+def _get_db():
+    """Return an open libgpod ``Database`` instance.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``python-gpod`` bindings are not installed.
+    """
+
+    if gpod is None:
+        raise RuntimeError("python-gpod bindings are required to use libpod_wrapper")
+
+    logger.debug("Opening iPod database at %s", IPOD_MOUNT)
+    return gpod.Database(str(IPOD_MOUNT))
+
+
+def add_track(filepath: Path) -> str | None:
+    """Import ``filepath`` into the iPod library.
+
+    Parameters
+    ----------
+    filepath:
+        Path to the audio file to import.  The file must already exist on the
+        local filesystem.
+
+    Returns
+    -------
+    str | None
+        The database identifier assigned to the new track, if available.
+    """
+
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(filepath)
+
+    db = _get_db()
+    logger.info("Importing %s", filepath)
+
+    track = db.new_track(str(filepath))
+    db.add_track(track)
+    db.copy_delayed_files()
+    db.close()
+
+    return getattr(track, "dbid", None)
 
 
 def delete_track(db_id: str) -> None:
-    """Delete a track from the iPod by its database ID."""
-    raise NotImplementedError("delete_track() not yet implemented")
+    """Remove a track with the given database identifier from the iPod."""
+
+    db = _get_db()
+    logger.info("Deleting track %s", db_id)
+
+    target = None
+    for track in list(getattr(db, "tracks", [])):
+        if str(getattr(track, "dbid", "")) == str(db_id):
+            target = track
+            break
+
+    if target is None:
+        db.close()
+        raise KeyError(f"Track {db_id!r} not found")
+
+    if hasattr(db, "remove_track"):
+        db.remove_track(target)
+    elif hasattr(db, "remove"):
+        db.remove(target)
+
+    db.copy_delayed_files()
+    db.close()
 
 
-def list_tracks():
-    """Return a list of tracks currently on the iPod."""
-    raise NotImplementedError("list_tracks() not yet implemented")
+def list_tracks() -> list[dict]:
+    """Return a list of dictionaries describing the tracks on the iPod."""
+
+    db = _get_db()
+    logger.debug("Listing tracks from iPod")
+    tracks = []
+    for track in getattr(db, "tracks", []):
+        tracks.append(
+            {
+                "id": getattr(track, "dbid", None),
+                "title": getattr(track, "title", None),
+                "artist": getattr(track, "artist", None),
+                "album": getattr(track, "album", None),
+            }
+        )
+
+    db.close()
+    return tracks
 

--- a/tests/test_libpod_wrapper.py
+++ b/tests/test_libpod_wrapper.py
@@ -1,0 +1,95 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ipod_sync.libpod_wrapper as wrapper
+
+
+class FakeTrack:
+    def __init__(self, path, dbid="1"):
+        self.path = path
+        self.dbid = dbid
+        self.title = "Test"
+        self.artist = "Artist"
+        self.album = "Album"
+
+
+class FakeDatabase:
+    def __init__(self):
+        self.tracks = []
+        self.new_track_called_with = None
+        self.copy_called = False
+        self.closed = False
+
+    def new_track(self, path):
+        self.new_track_called_with = path
+        return FakeTrack(path)
+
+    def add_track(self, track):
+        self.tracks.append(track)
+
+    def copy_delayed_files(self):
+        self.copy_called = True
+
+    def close(self):
+        self.closed = True
+
+    def remove_track(self, track):
+        self.tracks.remove(track)
+
+
+class FakeGpod:
+    def __init__(self):
+        self.db = FakeDatabase()
+        self.database_called_with = None
+
+    def Database(self, path):
+        self.database_called_with = path
+        return self.db
+
+
+def test_add_track_invokes_gpod(tmp_path):
+    fake = FakeGpod()
+    file_path = tmp_path / "song.mp3"
+    file_path.write_text("data")
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+
+    with mock.patch.object(wrapper, "gpod", fake), \
+         mock.patch.object(wrapper, "IPOD_MOUNT", mount):
+        wrapper.add_track(file_path)
+        assert fake.database_called_with == str(mount)
+        assert fake.db.new_track_called_with == str(file_path)
+        assert fake.db.copy_called
+        assert fake.db.closed
+
+
+def test_delete_track_removes_from_db(tmp_path):
+    fake = FakeGpod()
+    track = FakeTrack("/file")
+    fake.db.tracks.append(track)
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+
+    with mock.patch.object(wrapper, "gpod", fake), \
+         mock.patch.object(wrapper, "IPOD_MOUNT", mount):
+        wrapper.delete_track(track.dbid)
+        assert track not in fake.db.tracks
+        assert fake.db.copy_called
+        assert fake.db.closed
+
+
+def test_list_tracks_returns_metadata(tmp_path):
+    fake = FakeGpod()
+    fake.db.tracks.append(FakeTrack("/file", dbid="42"))
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+
+    with mock.patch.object(wrapper, "gpod", fake), \
+         mock.patch.object(wrapper, "IPOD_MOUNT", mount):
+        tracks = wrapper.list_tracks()
+        assert tracks == [{"id": "42", "title": "Test", "artist": "Artist", "album": "Album"}]
+        assert fake.db.closed


### PR DESCRIPTION
## Summary
- implement helper functions in `libpod_wrapper.py`
- document the wrapper in `development.md`
- add unit tests for libpod wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3425a37c8323963de41b303ae9b4