### PR TITLE
Implement sync queue processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ source .venv/bin/activate
 
 This repository will use the virtual environment for any Python tools and future dependencies.
 
+## Syncing files
+
+During the early development phase queued files can be synced manually using the
+`sync_from_queue` module:
+
+```bash
+python -m ipod_sync.sync_from_queue --device /dev/sda1
+```
+
+Any audio files placed in the `sync_queue/` directory will be imported to the
+iPod and removed from the queue.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,3 +45,19 @@ The module exposes three simple helpers:
 
 If the bindings are missing a `RuntimeError` will be raised when any of these
 functions are called.
+
+## Syncing from the queue
+
+`ipod_sync.sync_from_queue` provides a helper script to import any files placed
+in the `sync_queue/` directory.  It mounts the configured iPod device, calls
+`add_track()` for each queued file and ejects the iPod once finished.  By
+default files are removed from the queue after a successful import.
+
+Run the script manually with:
+
+```bash
+python -m ipod_sync.sync_from_queue --device /dev/sda1
+```
+
+The `--device` argument may be omitted if your iPod is available at the default
+path configured in `config.IPOD_DEVICE`.

--- a/ipod_sync/__init__.py
+++ b/ipod_sync/__init__.py
@@ -1,5 +1,5 @@
 """Core package for the ipod-dock project."""
 
-__all__ = ["app", "config", "libpod_wrapper", "utils"]
+__all__ = ["app", "config", "libpod_wrapper", "utils", "sync_from_queue"]
 
 __version__ = "0.1.0"

--- a/ipod_sync/config.py
+++ b/ipod_sync/config.py
@@ -10,3 +10,10 @@ LOG_DIR = PROJECT_ROOT / "logs"
 # Mount point of the iPod on the filesystem
 IPOD_MOUNT = PROJECT_ROOT / "mnt" / "ipod"
 
+# Default block device representing the iPod. This can be overridden
+# at runtime via command line arguments to the sync script.
+IPOD_DEVICE = "/dev/sda1"
+
+# Whether to keep a copy of files after they are successfully synced.
+KEEP_LOCAL_COPY = False
+

--- a/ipod_sync/sync_from_queue.py
+++ b/ipod_sync/sync_from_queue.py
@@ -1,0 +1,71 @@
+"""Simple script to sync files from :data:`~ipod_sync.config.SYNC_QUEUE_DIR`.
+
+The script mounts the iPod, imports any files found in the queue using
+:func:`~ipod_sync.libpod_wrapper.add_track`, and then ejects the device.
+Files are deleted from the queue after successful import unless
+:data:`~ipod_sync.config.KEEP_LOCAL_COPY` is set to ``True``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from . import config
+from .libpod_wrapper import add_track
+from .utils import mount_ipod, eject_ipod
+
+logger = logging.getLogger(__name__)
+
+
+def sync_queue(device: str = config.IPOD_DEVICE) -> None:
+    """Process all files waiting in the sync queue.
+
+    Parameters
+    ----------
+    device:
+        Block device path representing the iPod.
+    """
+
+    queue = Path(config.SYNC_QUEUE_DIR)
+    queue.mkdir(parents=True, exist_ok=True)
+
+    files = [f for f in sorted(queue.iterdir()) if f.is_file()]
+    if not files:
+        logger.info("No files to sync in %s", queue)
+        return
+
+    mount_ipod(device)
+    try:
+        for file in files:
+            try:
+                track_id = add_track(file)
+                size = file.stat().st_size
+                logger.info(
+                    "Synced %s (%d bytes) track_id=%s", file.name, size, track_id
+                )
+                if not config.KEEP_LOCAL_COPY:
+                    file.unlink()
+                    logger.debug("Deleted %s", file)
+            except Exception as exc:  # pragma: no cover - unexpected failures
+                logger.error("Failed to sync %s: %s", file, exc)
+    finally:
+        eject_ipod()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Sync queued files to an iPod")
+    parser.add_argument(
+        "--device",
+        default=config.IPOD_DEVICE,
+        help="Path to iPod block device (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    sync_queue(args.device)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/roadmap.md
+++ b/roadmap.md
@@ -3,9 +3,9 @@ Phase 1 – MVP: Manual Upload & Sync
 1.1	Set up development repo – create ipod_sync repo, add README, .gitignore, and issue template. ☑
 1.2     Install prerequisites – sudo apt install python3-gpod libgpod-common ffmpeg (Pi OS) + create a venv.    ☑
 1.3	Create project skeleton – folders: ipod_sync/, sync_queue/, uploads/, plus app.py, libpod_wrapper.py, config.py, utils.py.	☑
-1.4	Implement mount helpers (utils.py) – mount_ipod(), eject_ipod(), using subprocess to call mount/umount/eject.	☐
-1.5	Write libgpod wrapper (libpod_wrapper.py) – functions: add_track(filepath), delete_track(db_id), list_tracks().	☐
-1.6	Implement simple sync script (sync_from_queue.py) – watches sync_queue/, mounts iPod, calls add_track(), ejects.	☐
+1.4     Implement mount helpers (utils.py) – mount_ipod(), eject_ipod(), using subprocess to call mount/umount/eject.   ☑
+1.5     Write libgpod wrapper (libpod_wrapper.py) – functions: add_track(filepath), delete_track(db_id), list_tracks(). ☑
+1.6     Implement simple sync script (sync_from_queue.py) – watches sync_queue/, mounts iPod, calls add_track(), ejects.        ☑
 1.7	Add logging – log to logs/ipod_sync.log with rotation.	☐
 1.8	Test end-to-end – copy an MP3 to sync_queue/, run script, verify track appears on iPod after eject.	☐
 Phase 2 – Basic API & Web UI

--- a/tests/test_sync_from_queue.py
+++ b/tests/test_sync_from_queue.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ipod_sync import sync_from_queue
+
+
+@mock.patch("ipod_sync.sync_from_queue.add_track")
+@mock.patch("ipod_sync.sync_from_queue.eject_ipod")
+@mock.patch("ipod_sync.sync_from_queue.mount_ipod")
+def test_sync_queue_processes_files(mock_mount, mock_eject, mock_add, tmp_path):
+    queue = tmp_path / "queue"
+    queue.mkdir()
+    f1 = queue / "a.mp3"
+    f1.write_text("a")
+    f2 = queue / "b.mp3"
+    f2.write_text("b")
+
+    with mock.patch.object(sync_from_queue, "config", mock.Mock(SYNC_QUEUE_DIR=queue, IPOD_DEVICE="/dev/ipod", KEEP_LOCAL_COPY=False)):
+        sync_from_queue.sync_queue("/dev/ipod")
+
+    mock_mount.assert_called_once_with("/dev/ipod")
+    mock_eject.assert_called_once()
+    mock_add.assert_has_calls([mock.call(f1), mock.call(f2)], any_order=True)
+    assert not any(queue.iterdir())
+
+
+@mock.patch("ipod_sync.sync_from_queue.add_track")
+@mock.patch("ipod_sync.sync_from_queue.eject_ipod")
+@mock.patch("ipod_sync.sync_from_queue.mount_ipod")
+def test_sync_queue_no_files(mock_mount, mock_eject, mock_add, tmp_path):
+    queue = tmp_path / "queue"
+    queue.mkdir()
+
+    with mock.patch.object(sync_from_queue, "config", mock.Mock(SYNC_QUEUE_DIR=queue, IPOD_DEVICE="/dev/ipod", KEEP_LOCAL_COPY=False)):
+        sync_from_queue.sync_queue("/dev/ipod")
+
+    mock_mount.assert_not_called()
+    mock_eject.assert_not_called()
+    mock_add.assert_not_called()


### PR DESCRIPTION
## Summary
- add IPOD_DEVICE and KEEP_LOCAL_COPY config options
- implement `sync_from_queue` script to import queued files
- document new script in README and developer docs
- update package exports
- mark roadmap tasks 1.4-1.6 complete
- add tests for queue syncing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d38c7ac1c8323b1730214648e9859