### PR TITLE
Implement rotating file logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ python -m ipod_sync.sync_from_queue --device /dev/sda1
 Any audio files placed in the `sync_queue/` directory will be imported to the
 iPod and removed from the queue.
 
+Log output is written to `logs/ipod_sync.log` and rotated automatically. See
+`docs/development.md` for developer notes on the logging configuration.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,3 +61,10 @@ python -m ipod_sync.sync_from_queue --device /dev/sda1
 
 The `--device` argument may be omitted if your iPod is available at the default
 path configured in `config.IPOD_DEVICE`.
+
+## Logging
+
+The project writes application logs to `logs/ipod_sync.log`.  Logging is
+configured by `ipod_sync.logging_setup.setup_logging()` which installs a
+`RotatingFileHandler` keeping up to three 1 MB log files.  Unit tests use this
+helper to create temporary log files.

--- a/ipod_sync/__init__.py
+++ b/ipod_sync/__init__.py
@@ -1,5 +1,12 @@
 """Core package for the ipod-dock project."""
 
-__all__ = ["app", "config", "libpod_wrapper", "utils", "sync_from_queue"]
+__all__ = [
+    "app",
+    "config",
+    "libpod_wrapper",
+    "utils",
+    "sync_from_queue",
+    "logging_setup",
+]
 
 __version__ = "0.1.0"

--- a/ipod_sync/logging_setup.py
+++ b/ipod_sync/logging_setup.py
@@ -1,0 +1,38 @@
+"""Logging configuration utilities for ipod_sync."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from .config import LOG_DIR
+
+
+DEFAULT_LOG_FILE = LOG_DIR / "ipod_sync.log"
+
+
+def setup_logging(log_file: Path | str | None = None, level: int = logging.INFO) -> None:
+    """Configure application logging.
+
+    This sets up a :class:`~logging.handlers.RotatingFileHandler` that writes to
+    ``logs/ipod_sync.log`` by default. Log files are rotated when they reach
+    1 MB, keeping three backups.
+    """
+
+    path = Path(log_file) if log_file else DEFAULT_LOG_FILE
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    handler = RotatingFileHandler(path, maxBytes=1_048_576, backupCount=3)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+
+    if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
+        root_logger.addHandler(logging.StreamHandler())
+

--- a/ipod_sync/sync_from_queue.py
+++ b/ipod_sync/sync_from_queue.py
@@ -13,6 +13,7 @@ import logging
 from pathlib import Path
 
 from . import config
+from .logging_setup import setup_logging
 from .libpod_wrapper import add_track
 from .utils import mount_ipod, eject_ipod
 
@@ -67,5 +68,5 @@ def main(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    setup_logging()
     main()

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,7 +6,7 @@ Phase 1 – MVP: Manual Upload & Sync
 1.4     Implement mount helpers (utils.py) – mount_ipod(), eject_ipod(), using subprocess to call mount/umount/eject.   ☑
 1.5     Write libgpod wrapper (libpod_wrapper.py) – functions: add_track(filepath), delete_track(db_id), list_tracks(). ☑
 1.6     Implement simple sync script (sync_from_queue.py) – watches sync_queue/, mounts iPod, calls add_track(), ejects.        ☑
-1.7	Add logging – log to logs/ipod_sync.log with rotation.	☐
+1.7	Add logging – log to logs/ipod_sync.log with rotation.	☑
 1.8	Test end-to-end – copy an MP3 to sync_queue/, run script, verify track appears on iPod after eject.	☐
 Phase 2 – Basic API & Web UI
 #	Task	

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import logging
+from logging.handlers import RotatingFileHandler
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ipod_sync.logging_setup import setup_logging
+
+
+def test_setup_logging_creates_rotating_handler(tmp_path):
+    log_file = tmp_path / "my.log"
+    setup_logging(log_file, level=logging.DEBUG)
+    logger = logging.getLogger()
+    handler = next(h for h in logger.handlers if isinstance(h, RotatingFileHandler))
+    assert Path(handler.baseFilename) == log_file
+    logger.debug("test")
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- add `logging_setup` module with rotating log file handler
- hook logging setup into `sync_from_queue`
- document logging in README and docs
- mark roadmap task 1.7 as complete
- test new logging configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3ad764288323bbaba778e792a45d