### PR TITLE
Add FastAPI API with upload and track management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ iPod and removed from the queue.
 Log output is written to `logs/ipod_sync.log` and rotated automatically. See
 `docs/development.md` for developer notes on the logging configuration.
 
+
+## Web API
+
+A small FastAPI application exposes upload and track management endpoints. Start
+the server for development with:
+
+```bash
+python -m ipod_sync.app
+```
+
+See [docs/development.md](docs/development.md) for the list of endpoints.

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,3 +68,22 @@ The project writes application logs to `logs/ipod_sync.log`.  Logging is
 configured by `ipod_sync.logging_setup.setup_logging()` which installs a
 `RotatingFileHandler` keeping up to three 1 MB log files.  Unit tests use this
 helper to create temporary log files.
+
+## Web API
+
+The `ipod_sync.app` module exposes a small FastAPI application. Run a local
+server with:
+
+```bash
+python -m ipod_sync.app
+```
+
+Endpoints:
+
+- `GET /status` – simple health check returning `{"status": "ok"}`.
+- `POST /upload` – upload a file; it is saved to `sync_queue/` for later sync.
+- `GET /tracks` – list tracks on the iPod. The iPod is mounted automatically.
+- `DELETE /tracks/{id}` – remove a track by its database ID. The iPod is mounted
+  and ejected for the operation.
+
+The API uses the same rotating log configuration as the sync script.

--- a/ipod_sync/__init__.py
+++ b/ipod_sync/__init__.py
@@ -1,6 +1,7 @@
 """Core package for the ipod-dock project."""
 
 __all__ = [
+    "api_helpers",
     "app",
     "config",
     "libpod_wrapper",

--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -1,0 +1,57 @@
+"""Helper functions used by the web API endpoints."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from . import config
+from .libpod_wrapper import list_tracks, delete_track
+from .utils import mount_ipod, eject_ipod
+
+logger = logging.getLogger(__name__)
+
+
+def save_to_queue(name: str, data: bytes, queue_dir: Path | None = None) -> Path:
+    """Save uploaded file data to the sync queue directory.
+
+    Parameters
+    ----------
+    name:
+        Original filename of the uploaded content.
+    data:
+        File bytes to write.
+    queue_dir:
+        Destination directory for queued files. Defaults to
+        :data:`~ipod_sync.config.SYNC_QUEUE_DIR`.
+
+    Returns
+    -------
+    Path
+        The path to the written file.
+    """
+    queue = Path(queue_dir) if queue_dir else Path(config.SYNC_QUEUE_DIR)
+    queue.mkdir(parents=True, exist_ok=True)
+    dest = queue / name
+    with dest.open("wb") as fh:
+        fh.write(data)
+    logger.info("Saved %s to queue", dest)
+    return dest
+
+
+def get_tracks(device: str = config.IPOD_DEVICE) -> list[dict]:
+    """Mount the iPod and return a list of track metadata."""
+    mount_ipod(device)
+    try:
+        return list_tracks()
+    finally:
+        eject_ipod()
+
+
+def remove_track(db_id: str, device: str = config.IPOD_DEVICE) -> None:
+    """Delete a track from the iPod by its database ID."""
+    mount_ipod(device)
+    try:
+        delete_track(db_id)
+    finally:
+        eject_ipod()

--- a/ipod_sync/app.py
+++ b/ipod_sync/app.py
@@ -1,11 +1,65 @@
-"""Entry point for the ipod_sync application."""
+"""FastAPI application exposing basic iPod management endpoints."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+
+from . import config
+from .logging_setup import setup_logging
+from .api_helpers import save_to_queue, get_tracks, remove_track
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="ipod-dock")
+
+
+@app.get("/status")
+async def status() -> dict:
+    """Return service health information."""
+    logger.debug("Status check")
+    return {"status": "ok"}
+
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)) -> dict:
+    """Accept a file upload and place it in the sync queue."""
+    data = await file.read()
+    path = save_to_queue(file.filename, data)
+    return {"queued": path.name}
+
+
+@app.get("/tracks")
+async def tracks() -> list[dict]:
+    """Return the list of tracks currently on the iPod."""
+    try:
+        return get_tracks(config.IPOD_DEVICE)
+    except Exception as exc:
+        logger.error("Failed to list tracks: %s", exc)
+        raise HTTPException(500, str(exc))
+
+
+@app.delete("/tracks/{track_id}")
+async def delete_track(track_id: str) -> dict:
+    """Remove a track from the iPod."""
+    try:
+        remove_track(track_id, config.IPOD_DEVICE)
+    except KeyError:
+        raise HTTPException(404, "Track not found")
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        logger.error("Failed to delete track %s: %s", track_id, exc)
+        raise HTTPException(500, str(exc))
+    return {"deleted": track_id}
 
 
 def main() -> None:
-    """Placeholder main function."""
-    print("ipod-sync skeleton")
+    """Run a development server if executed as a script."""
+    import uvicorn
+
+    setup_logging()
+    uvicorn.run("ipod_sync.app:app", host="0.0.0.0", port=8000, log_level="info")
 
 
 if __name__ == "__main__":
     main()
-

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,10 +10,10 @@ Phase 1 – MVP: Manual Upload & Sync
 1.8	Test end-to-end – copy an MP3 to sync_queue/, run script, verify track appears on iPod after eject.	☐
 Phase 2 – Basic API & Web UI
 #	Task	
-2.1	Add Flask/FastAPI – scaffold app.py with /status (health) endpoint.	☐
-2.2	POST /upload endpoint – accept file upload, save to sync_queue/, return JSON.	☐
-2.3	GET /tracks endpoint – return JSON list from list_tracks().	☐
-2.4	DELETE /tracks/<id> endpoint – remove a track, re-write DB, eject.	☐
+2.1	Add Flask/FastAPI – scaffold app.py with /status (health) endpoint. ☑
+2.2	POST /upload endpoint – accept file upload, save to sync_queue/, return JSON. ☑
+2.3	GET /tracks endpoint – return JSON list from list_tracks(). ☑
+2.4	DELETE /tracks/<id> endpoint – remove a track, re-write DB, eject. ☑
 2.5	Add simple HTML UI – use Bootstrap/Tailwind, fetch /tracks, show table, upload form.	☐
 2.6	Systemd service – create unit file for API + sync watcher so they start on boot.	☐
 Phase 3 – Dock Detection & Playback Control

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from unittest import mock
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ipod_sync import api_helpers
+
+
+def test_save_to_queue_writes_file(tmp_path):
+    dest = api_helpers.save_to_queue("a.mp3", b"data", tmp_path)
+    assert dest.exists()
+    assert dest.read_bytes() == b"data"
+
+
+@mock.patch("ipod_sync.api_helpers.list_tracks")
+@mock.patch("ipod_sync.api_helpers.eject_ipod")
+@mock.patch("ipod_sync.api_helpers.mount_ipod")
+def test_get_tracks_mounts_and_ejects(mock_mount, mock_eject, mock_list):
+    mock_list.return_value = [{"id": "1"}]
+    tracks = api_helpers.get_tracks("/dev/ipod")
+    mock_mount.assert_called_once_with("/dev/ipod")
+    mock_eject.assert_called_once()
+    assert tracks == [{"id": "1"}]
+
+
+@mock.patch("ipod_sync.api_helpers.delete_track")
+@mock.patch("ipod_sync.api_helpers.eject_ipod")
+@mock.patch("ipod_sync.api_helpers.mount_ipod")
+def test_remove_track_calls_lib(mock_mount, mock_eject, mock_delete):
+    api_helpers.remove_track("42", "/dev/ipod")
+    mock_mount.assert_called_once_with("/dev/ipod")
+    mock_delete.assert_called_once_with("42")
+    mock_eject.assert_called_once()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from unittest import mock
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+from ipod_sync.app import app
+import ipod_sync.app as app_module
+
+client = TestClient(app)
+
+
+def test_status_endpoint():
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@mock.patch.object(app_module, "save_to_queue")
+def test_upload_endpoint(mock_save):
+    mock_save.return_value = Path("sync_queue/foo.mp3")
+    response = client.post("/upload", files={"file": ("foo.mp3", b"abc")})
+    assert response.status_code == 200
+    assert response.json() == {"queued": "foo.mp3"}
+    mock_save.assert_called_once()
+
+
+@mock.patch.object(app_module, "get_tracks", return_value=[{"id": "1"}])
+def test_tracks_endpoint(mock_get):
+    response = client.get("/tracks")
+    assert response.status_code == 200
+    assert response.json() == [{"id": "1"}]
+    mock_get.assert_called_once()
+
+
+@mock.patch.object(app_module, "remove_track")
+def test_delete_track_endpoint(mock_remove):
+    response = client.delete("/tracks/42")
+    assert response.status_code == 200
+    assert response.json() == {"deleted": "42"}
+    mock_remove.assert_called_once_with("42", app_module.config.IPOD_DEVICE)
+
+
+@mock.patch.object(app_module, "remove_track", side_effect=KeyError)
+def test_delete_track_not_found(mock_remove):
+    response = client.delete("/tracks/99")
+    assert response.status_code == 404
+    mock_remove.assert_called_once_with("99", app_module.config.IPOD_DEVICE)


### PR DESCRIPTION
## Summary
- implement FastAPI application with `/status`, `/upload`, `/tracks` and delete
- add helper functions for API operations
- document new API and update README
- mark roadmap tasks as complete
- tests for API helpers and endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3cbc76288323970b0b3f5e71a9b0