### PR TITLE
Add plugin API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ python -m ipod_sync.app
 ```
 
 See [docs/development.md](docs/development.md) for the list of endpoints.
+Plugin developers can find usage examples in
+[docs/plugin_api.md](docs/plugin_api.md).

--- a/docs/plugin_api.md
+++ b/docs/plugin_api.md
@@ -1,0 +1,61 @@
+# Plugin API
+
+This document describes the simple REST interface provided by the project. It is intended for developers writing integrations (for example MusicBee or AudioBookShelf plugins) that need to send audio files to the Raspberry Pi and manage the iPod library.
+
+## Starting the server
+
+Run the FastAPI application with:
+
+```bash
+python -m ipod_sync.app
+```
+
+By default it listens on port `8000` on all interfaces. The examples below assume the Pi is reachable as `http://<pi>:8000`.
+
+## Endpoints
+
+### `GET /status`
+Returns a basic health check.
+
+```json
+{"status": "ok"}
+```
+
+### `POST /upload`
+Upload an audio file. The request must use `multipart/form-data` with a single field named `file`.
+
+Example using `curl`:
+
+```bash
+curl -F "file=@song.mp3" http://<pi>:8000/upload
+```
+
+A successful request returns the queued filename:
+
+```json
+{"queued": "song.mp3"}
+```
+
+Files are written to the queue directory on the Pi and processed by the sync script.
+
+### `GET /tracks`
+Retrieve the list of tracks currently on the iPod. Each item contains minimal metadata:
+
+```json
+[
+  {"id": "1", "title": "Track Title", "artist": "Artist", "album": "Album"}
+]
+```
+
+### `DELETE /tracks/{id}`
+Remove a track by its database identifier. On success the response is:
+
+```json
+{"deleted": "<id>"}
+```
+
+A `404` status is returned if the track does not exist.
+
+## Notes
+
+Authentication has not yet been implemented, so the API should only be exposed on trusted networks. Uploaded files must be in a format supported by the iPod (typically MP3 or AAC); conversion is outside the scope of the API.


### PR DESCRIPTION
## Summary
- document REST API usage for plugin authors
- link to the new document from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d403c31408323b4efe47ebca2dd98