### PR TITLE
Add category option for uploads

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -82,6 +82,7 @@ Endpoints:
 
 - `GET /status` – simple health check returning `{"status": "ok"}`.
 - `POST /upload` – upload a file; it is saved to `sync_queue/` for later sync.
+- `POST /upload/{category}` – upload a file to a specific category (`music` or `audiobook`).
 - `GET /tracks` – list tracks on the iPod. The iPod is mounted automatically.
 - `DELETE /tracks/{id}` – remove a track by its database ID. The iPod is mounted
   and ejected for the operation.

--- a/docs/plugin_api.md
+++ b/docs/plugin_api.md
@@ -38,6 +38,19 @@ A successful request returns the queued filename:
 
 Files are written to the queue directory on the Pi and processed by the sync script.
 
+### `POST /upload/{category}`
+Upload a file to a specific category. `category` must be either `music` or `audiobook`.
+
+```bash
+curl -F "file=@book.m4b" http://<pi>:8000/upload/audiobook
+```
+
+The response includes the queued filename and the category:
+
+```json
+{"queued": "book.m4b", "category": "audiobook"}
+```
+
 ### `GET /tracks`
 Retrieve the list of tracks currently on the iPod. Each item contains minimal metadata:
 

--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -12,7 +12,12 @@ from .utils import mount_ipod, eject_ipod
 logger = logging.getLogger(__name__)
 
 
-def save_to_queue(name: str, data: bytes, queue_dir: Path | None = None) -> Path:
+def save_to_queue(
+    name: str,
+    data: bytes,
+    queue_dir: Path | None = None,
+    category: str | None = None,
+) -> Path:
     """Save uploaded file data to the sync queue directory.
 
     Parameters
@@ -24,6 +29,10 @@ def save_to_queue(name: str, data: bytes, queue_dir: Path | None = None) -> Path
     queue_dir:
         Destination directory for queued files. Defaults to
         :data:`~ipod_sync.config.SYNC_QUEUE_DIR`.
+    category:
+        Optional subdirectory for categorizing uploads (e.g. ``"music"`` or
+        ``"audiobook"``). If provided the file will be written inside this
+        subfolder.
 
     Returns
     -------
@@ -31,6 +40,8 @@ def save_to_queue(name: str, data: bytes, queue_dir: Path | None = None) -> Path
         The path to the written file.
     """
     queue = Path(queue_dir) if queue_dir else Path(config.SYNC_QUEUE_DIR)
+    if category:
+        queue = queue / category
     queue.mkdir(parents=True, exist_ok=True)
     dest = queue / name
     with dest.open("wb") as fh:

--- a/ipod_sync/app.py
+++ b/ipod_sync/app.py
@@ -40,6 +40,16 @@ async def upload(file: UploadFile = File(...)) -> dict:
     return {"queued": path.name}
 
 
+@app.post("/upload/{category}")
+async def upload_category(category: str, file: UploadFile = File(...)) -> dict:
+    """Upload a file to a specific category such as ``music`` or ``audiobook``."""
+    if category not in {"music", "audiobook"}:
+        raise HTTPException(400, "invalid category")
+    data = await file.read()
+    path = save_to_queue(file.filename, data, category=category)
+    return {"queued": path.name, "category": category}
+
+
 @app.get("/tracks")
 async def tracks() -> list[dict]:
     """Return the list of tracks currently on the iPod."""

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -13,6 +13,11 @@ def test_save_to_queue_writes_file(tmp_path):
     assert dest.exists()
     assert dest.read_bytes() == b"data"
 
+def test_save_to_queue_category(tmp_path):
+    dest = api_helpers.save_to_queue("b.mp3", b"data", tmp_path, category="music")
+    assert dest.parent.name == "music"
+    assert dest.exists()
+
 
 @mock.patch("ipod_sync.api_helpers.list_tracks")
 @mock.patch("ipod_sync.api_helpers.eject_ipod")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,6 +27,20 @@ def test_upload_endpoint(mock_save):
     mock_save.assert_called_once()
 
 
+@mock.patch.object(app_module, "save_to_queue")
+def test_upload_category_endpoint(mock_save):
+    mock_save.return_value = Path("sync_queue/audiobook/foo.m4b")
+    response = client.post("/upload/audiobook", files={"file": ("foo.m4b", b"abc")})
+    assert response.status_code == 200
+    assert response.json() == {"queued": "foo.m4b", "category": "audiobook"}
+    mock_save.assert_called_once_with("foo.m4b", b"abc", category="audiobook")
+
+
+def test_upload_category_invalid():
+    response = client.post("/upload/invalid", files={"file": ("foo.mp3", b"abc")})
+    assert response.status_code == 400
+
+
 @mock.patch.object(app_module, "get_tracks", return_value=[{"id": "1"}])
 def test_tracks_endpoint(mock_get):
     response = client.get("/tracks")


### PR DESCRIPTION
## Summary
- support category subdirectories when saving to queue
- add `/upload/{category}` endpoint
- document new API endpoints in developer and plugin docs
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d416c404883239549fdcfa51256b4