### PR TITLE
Implement advanced UI and API endpoints

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -86,13 +86,18 @@ Endpoints:
 - `GET /tracks` – list tracks on the iPod. The iPod is mounted automatically.
 - `DELETE /tracks/{id}` – remove a track by its database ID. The iPod is mounted
   and ejected for the operation.
+- `GET /queue` – list files currently waiting in the sync queue.
+- `POST /queue/clear` – remove all files from the queue.
+- `POST /sync` – import queued files onto the iPod immediately.
+- `GET /stats` – return counts for the dashboard (tracks, queue size, disk usage).
 
 The API uses the same rotating log configuration as the sync script.
 
 ## Web UI
 
-When the FastAPI server is running you can open `http://localhost:8000/` in a
-browser to view a very small HTML interface. It is built with the Bootstrap CDN
-and uses JavaScript `fetch()` calls to the API endpoints. The page allows you to
-upload files and shows the list of tracks returned by `GET /tracks` in a table.
+Start the FastAPI server and open `http://localhost:8000/` in a browser to see
+the web dashboard.  The interface loads its CSS and JavaScript from the
+`/static` directory and communicates with the API via `fetch()` calls.  Drag and
+drop files onto the upload area, trigger a manual sync and browse tracks, queued
+files or audiobooks from the tabbed view.
 

--- a/docs/plugin_api.md
+++ b/docs/plugin_api.md
@@ -69,6 +69,18 @@ Remove a track by its database identifier. On success the response is:
 
 A `404` status is returned if the track does not exist.
 
+### `GET /queue`
+Return a list of files waiting in the sync queue.
+
+### `POST /queue/clear`
+Remove all files from the queue.
+
+### `POST /sync`
+Import queued files onto the iPod immediately.
+
+### `GET /stats`
+Return basic dashboard information such as track count, queue size and storage usage.
+
 ## Notes
 
 Authentication has not yet been implemented, so the API should only be exposed on trusted networks. Uploaded files must be in a format supported by the iPod (typically MP3 or AAC); conversion is outside the scope of the API.

--- a/ipod_sync/static/app.js
+++ b/ipod_sync/static/app.js
@@ -1,0 +1,198 @@
+let currentTab = 'music';
+let tracks = [];
+let uploadQueue = [];
+
+async function initializeApp() {
+    await loadTracks();
+    await updateStats();
+    setupEventListeners();
+}
+
+function setupEventListeners() {
+    const uploadArea = document.getElementById('upload-area');
+    const fileInput = document.getElementById('file-input');
+    const searchInput = document.getElementById('search-input');
+
+    uploadArea.addEventListener('click', () => fileInput.click());
+    uploadArea.addEventListener('dragover', handleDragOver);
+    uploadArea.addEventListener('dragleave', handleDragLeave);
+    uploadArea.addEventListener('drop', handleDrop);
+    fileInput.addEventListener('change', handleFileSelect);
+    searchInput.addEventListener('input', handleSearch);
+}
+
+function handleDragOver(e) {
+    e.preventDefault();
+    e.currentTarget.classList.add('drag-over');
+}
+
+function handleDragLeave(e) {
+    e.preventDefault();
+    e.currentTarget.classList.remove('drag-over');
+}
+
+function handleDrop(e) {
+    e.preventDefault();
+    e.currentTarget.classList.remove('drag-over');
+    const files = Array.from(e.dataTransfer.files);
+    handleFiles(files);
+}
+
+function handleFileSelect(e) {
+    const files = Array.from(e.target.files);
+    handleFiles(files);
+}
+
+async function handleFiles(files) {
+    const progressBar = document.getElementById('progress-bar');
+    const progressFill = document.getElementById('progress-fill');
+    progressBar.style.display = 'block';
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        const formData = new FormData();
+        let endpoint = '/upload';
+        if (file.name.endsWith('.m4b')) {
+            endpoint += '/audiobook';
+        } else {
+            endpoint += '/music';
+        }
+        formData.append('file', file);
+        await fetch(endpoint, { method: 'POST', body: formData });
+        progressFill.style.width = ((i + 1) / files.length) * 100 + '%';
+    }
+    progressBar.style.display = 'none';
+    progressFill.style.width = '0%';
+    showNotification('Upload completed successfully!', 'success');
+    await updateStats();
+    if (currentTab === 'queue') loadTracks();
+}
+
+function switchTab(tab, element) {
+    currentTab = tab;
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    element.classList.add('active');
+    loadTracks();
+}
+
+async function loadTracks() {
+    const res = await fetch('/tracks');
+    tracks = await res.json();
+    const grid = document.getElementById('track-grid');
+    let filteredTracks = tracks;
+    if (currentTab === 'queue') {
+        await loadQueue();
+        return;
+    } else if (currentTab === 'audiobooks') {
+        filteredTracks = tracks.filter(t => t.type === 'audiobook');
+    } else {
+        filteredTracks = tracks.filter(t => t.type !== 'audiobook');
+    }
+    grid.innerHTML = filteredTracks.length === 0 ?
+        '<div style="text-align: center; color: #666; padding: 40px;">No tracks found</div>' :
+        filteredTracks.map(track => `
+            <div class="track-item ${track.type || ''}">
+                <div class="track-title">${track.title || ''}</div>
+                <div class="track-meta">
+                    <span>${track.artist || ''} • ${track.album || ''}</span>
+                    <span>${track.duration || ''}</span>
+                </div>
+                <div class="track-actions">
+                    <button class="btn btn-small" onclick="playTrack('${track.id}')">▶️ Play</button>
+                    <button class="btn btn-small btn-secondary" onclick="removeTrack('${track.id}')">🗑️ Remove</button>
+                </div>
+            </div>
+        `).join('');
+}
+
+async function loadQueue() {
+    const res = await fetch('/queue');
+    const items = await res.json();
+    const grid = document.getElementById('track-grid');
+    grid.innerHTML = items.length === 0 ?
+        '<div style="text-align: center; color: #666; padding: 40px;">No files in queue</div>' :
+        items.map(file => `
+            <div class="track-item">
+                <div class="track-title">${file.name}</div>
+                <div class="track-meta">
+                    <span>Size: ${(file.size / 1024 / 1024).toFixed(1)} MB</span>
+                    <span>Pending upload</span>
+                </div>
+            </div>
+        `).join('');
+}
+
+function handleSearch() {
+    const query = document.getElementById('search-input').value.toLowerCase();
+    const filteredTracks = tracks.filter(track =>
+        (track.title || '').toLowerCase().includes(query) ||
+        (track.artist || '').toLowerCase().includes(query) ||
+        (track.album || '').toLowerCase().includes(query)
+    );
+    const grid = document.getElementById('track-grid');
+    grid.innerHTML = filteredTracks.map(track => `
+        <div class="track-item ${track.type || ''}">
+            <div class="track-title">${track.title || ''}</div>
+            <div class="track-meta">
+                <span>${track.artist || ''} • ${track.album || ''}</span>
+                <span>${track.duration || ''}</span>
+            </div>
+            <div class="track-actions">
+                <button class="btn btn-small" onclick="playTrack('${track.id}')">▶️ Play</button>
+                <button class="btn btn-small btn-secondary" onclick="removeTrack('${track.id}')">🗑️ Remove</button>
+            </div>
+        </div>
+    `).join('');
+}
+
+async function updateStats() {
+    const res = await fetch('/stats');
+    const stats = await res.json();
+    document.getElementById('music-count').textContent = stats.music;
+    document.getElementById('audiobook-count').textContent = stats.audiobooks;
+    document.getElementById('storage-used').textContent = stats.storage_used + '%';
+    document.getElementById('sync-queue').textContent = stats.queue;
+}
+
+async function syncNow() {
+    const statusIndicator = document.getElementById('status-indicator');
+    const statusText = document.getElementById('status-text');
+
+    statusIndicator.className = 'status-indicator status-syncing';
+    statusText.textContent = 'Syncing...';
+    await fetch('/sync', { method: 'POST' });
+    await updateStats();
+    statusIndicator.className = 'status-indicator status-connected';
+    statusText.textContent = 'iPod Connected';
+    document.getElementById('last-sync').textContent = new Date().toLocaleTimeString();
+    showNotification('Sync completed successfully!', 'success');
+}
+
+async function clearQueue() {
+    await fetch('/queue/clear', { method: 'POST' });
+    showNotification('Queue cleared', 'success');
+    await updateStats();
+    if (currentTab === 'queue') loadTracks();
+}
+
+function playTrack(id) {
+    showNotification('Play functionality is not implemented', 'error');
+}
+
+async function removeTrack(id) {
+    await fetch('/tracks/' + id, { method: 'DELETE' });
+    showNotification('Track removed', 'success');
+    await loadTracks();
+    await updateStats();
+}
+
+function showNotification(message, type = 'success') {
+    const notification = document.getElementById('notification');
+    const notificationText = document.getElementById('notification-text');
+    notificationText.textContent = message;
+    notification.className = `notification ${type} show`;
+    setTimeout(() => {
+        notification.classList.remove('show');
+    }, 3000);
+}
+
+document.addEventListener('DOMContentLoaded', initializeApp);

--- a/ipod_sync/static/style.css
+++ b/ipod_sync/static/style.css
@@ -1,0 +1,358 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    color: #333;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.header {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 30px;
+    margin-bottom: 30px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    text-align: center;
+}
+
+.header h1 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 10px;
+}
+
+.header p {
+    color: #666;
+    font-size: 1.1rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.stat-card {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 15px;
+    padding: 25px;
+    text-align: center;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+}
+
+.stat-number {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #667eea;
+    margin-bottom: 5px;
+}
+
+.stat-label {
+    color: #666;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.main-content {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 30px;
+    margin-bottom: 30px;
+}
+
+.upload-section {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 30px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.section-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+    color: #333;
+}
+
+.upload-area {
+    border: 3px dashed #ccc;
+    border-radius: 15px;
+    padding: 40px 20px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    margin-bottom: 20px;
+}
+
+.upload-area.drag-over {
+    border-color: #667eea;
+    background: rgba(102, 126, 234, 0.1);
+}
+
+.upload-area:hover {
+    border-color: #667eea;
+    background: rgba(102, 126, 234, 0.05);
+}
+
+.upload-icon {
+    font-size: 3rem;
+    color: #ccc;
+    margin-bottom: 15px;
+}
+
+.upload-text {
+    color: #666;
+    font-size: 1.1rem;
+    margin-bottom: 15px;
+}
+
+.file-input {
+    display: none;
+}
+
+.btn {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 25px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 1rem;
+}
+
+.btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.btn-secondary {
+    background: linear-gradient(135deg, #ff7e5f, #feb47b);
+}
+
+.btn-secondary:hover {
+    box-shadow: 0 6px 20px rgba(255, 126, 95, 0.4);
+}
+
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #f0f0f0;
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 15px 0;
+    display: none;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    width: 0%;
+    transition: width 0.3s ease;
+}
+
+.content-section {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 30px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.tabs {
+    display: flex;
+    margin-bottom: 25px;
+    background: #f8f9fa;
+    border-radius: 12px;
+    padding: 5px;
+}
+
+.tab {
+    flex: 1;
+    padding: 12px 20px;
+    text-align: center;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-weight: 500;
+}
+
+.tab.active {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+}
+
+.search-bar {
+    width: 100%;
+    padding: 15px 20px;
+    border: 2px solid #f0f0f0;
+    border-radius: 25px;
+    font-size: 1rem;
+    margin-bottom: 20px;
+    transition: border-color 0.3s ease;
+}
+
+.search-bar:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.track-grid {
+    display: grid;
+    gap: 15px;
+    max-height: 500px;
+    overflow-y: auto;
+    padding-right: 10px;
+}
+
+.track-item {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    border-left: 4px solid #667eea;
+}
+
+.track-item:hover {
+    transform: translateX(5px);
+    box-shadow: 0 6px 25px rgba(0, 0, 0, 0.12);
+}
+
+.track-item.audiobook {
+    border-left-color: #ff7e5f;
+}
+
+.track-title {
+    font-weight: 600;
+    font-size: 1.1rem;
+    margin-bottom: 5px;
+    color: #333;
+}
+
+.track-meta {
+    color: #666;
+    font-size: 0.9rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.track-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
+}
+
+.btn-small {
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    border-radius: 15px;
+}
+
+.sync-status {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    padding: 20px;
+    border-radius: 15px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    min-width: 250px;
+    text-align: center;
+}
+
+.status-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 8px;
+}
+
+.status-connected {
+    background: #4CAF50;
+}
+
+.status-syncing {
+    background: #FF9800;
+    animation: pulse 1.5s infinite;
+}
+
+.status-error {
+    background: #F44336;
+}
+
+@keyframes pulse {
+    0% { opacity: 1; }
+    50% { opacity: 0.5; }
+    100% { opacity: 1; }
+}
+
+@media (max-width: 768px) {
+    .main-content {
+        grid-template-columns: 1fr;
+    }
+    
+    .header h1 {
+        font-size: 2rem;
+    }
+    
+    .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.notification {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    padding: 15px 20px;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    transform: translateX(400px);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+}
+
+.notification.show {
+    transform: translateX(0);
+}
+
+.notification.success {
+    border-left: 4px solid #4CAF50;
+}
+
+.notification.error {
+    border-left: 4px solid #F44336;
+}
+

--- a/ipod_sync/templates/index.html
+++ b/ipod_sync/templates/index.html
@@ -4,55 +4,83 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>iPod Dock</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="container py-4">
-    <h1 class="mb-4">iPod Dock</h1>
-
-    <form id="upload-form" class="mb-3">
-        <div class="input-group">
-            <input type="file" name="file" class="form-control" required>
-            <button class="btn btn-primary" type="submit">Upload</button>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🎵 iPod Dock</h1>
+            <p>Wireless Music & Audiobook Manager</p>
         </div>
-    </form>
 
-    <table id="track-table" class="table table-striped">
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>Title</th>
-                <th>Artist</th>
-                <th>Album</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-number" id="music-count">0</div>
+                <div class="stat-label">Music Tracks</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-number" id="audiobook-count">0</div>
+                <div class="stat-label">Audiobooks</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-number" id="storage-used">0%</div>
+                <div class="stat-label">Storage Used</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-number" id="sync-queue">0</div>
+                <div class="stat-label">Queue to Sync</div>
+            </div>
+        </div>
 
-    <script>
-        async function loadTracks() {
-            const res = await fetch('/tracks');
-            const tracks = await res.json();
-            const tbody = document.querySelector('#track-table tbody');
-            tbody.innerHTML = '';
-            for (const t of tracks) {
-                const row = document.createElement('tr');
-                row.innerHTML = `<td>${t.id ?? ''}</td><td>${t.title ?? ''}</td><td>${t.artist ?? ''}</td><td>${t.album ?? ''}</td>`;
-                tbody.appendChild(row);
-            }
-        }
+        <div class="main-content">
+            <div class="upload-section">
+                <h2 class="section-title">📤 Upload Files</h2>
+                <div class="upload-area" id="upload-area">
+                    <div class="upload-icon">📁</div>
+                    <div class="upload-text">
+                        <strong>Drop files here</strong><br>
+                        or click to browse
+                    </div>
+                    <input type="file" id="file-input" class="file-input" multiple accept=".mp3,.m4a,.flac,.wav,.m4b">
+                </div>
+                <div class="progress-bar" id="progress-bar">
+                    <div class="progress-fill" id="progress-fill"></div>
+                </div>
+                <div style="display: flex; gap: 10px; margin-top: 20px;">
+                    <button class="btn" onclick="syncNow()">🔄 Sync Now</button>
+                    <button class="btn btn-secondary" onclick="clearQueue()">🗑️ Clear Queue</button>
+                </div>
+            </div>
 
-        document.getElementById('upload-form').addEventListener('submit', async e => {
-            e.preventDefault();
-            const fileInput = e.target.elements.file;
-            if (fileInput.files.length === 0) return;
-            const formData = new FormData();
-            formData.append('file', fileInput.files[0]);
-            await fetch('/upload', { method: 'POST', body: formData });
-            fileInput.value = '';
-            loadTracks();
-        });
+            <div class="content-section">
+                <div class="tabs">
+                    <div class="tab active" onclick="switchTab('music', this)">🎵 Music</div>
+                    <div class="tab" onclick="switchTab('audiobooks', this)">📚 Audiobooks</div>
+                    <div class="tab" onclick="switchTab('queue', this)">⏳ Queue</div>
+                </div>
 
-        loadTracks();
-    </script>
+                <input type="text" class="search-bar" placeholder="🔍 Search your library..." id="search-input">
+
+                <div class="track-grid" id="track-grid">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="sync-status">
+        <div>
+            <span class="status-indicator status-connected" id="status-indicator"></span>
+            <span id="status-text">iPod Connected</span>
+        </div>
+        <div style="font-size: 0.8rem; color: #666; margin-top: 5px;">
+            Last sync: <span id="last-sync">Never</span>
+        </div>
+    </div>
+
+    <div class="notification" id="notification">
+        <div id="notification-text"></div>
+    </div>
+
+    <script src="/static/app.js"></script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -63,6 +63,38 @@ def test_delete_track_not_found(mock_remove):
     assert response.status_code == 404
     mock_remove.assert_called_once_with("99", app_module.config.IPOD_DEVICE)
 
+
+@mock.patch.object(app_module, "list_queue", return_value=[{"name": "a.mp3"}])
+def test_queue_endpoint(mock_list):
+    response = client.get("/queue")
+    assert response.status_code == 200
+    assert response.json() == [{"name": "a.mp3"}]
+    mock_list.assert_called_once()
+
+
+@mock.patch.object(app_module, "clear_queue")
+def test_queue_clear_endpoint(mock_clear):
+    response = client.post("/queue/clear")
+    assert response.status_code == 200
+    assert response.json() == {"cleared": True}
+    mock_clear.assert_called_once()
+
+
+@mock.patch.object(app_module, "sync_from_queue")
+def test_sync_endpoint(mock_sync):
+    response = client.post("/sync")
+    assert response.status_code == 200
+    assert response.json() == {"synced": True}
+    mock_sync.sync_queue.assert_called_once_with(app_module.config.IPOD_DEVICE)
+
+
+@mock.patch.object(app_module, "get_stats", return_value={"music": 1})
+def test_stats_endpoint(mock_stats):
+    response = client.get("/stats")
+    assert response.status_code == 200
+    assert response.json() == {"music": 1}
+    mock_stats.assert_called_once_with(app_module.config.IPOD_DEVICE)
+
 def test_index_page():
     response = client.get("/")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- replace index page with polished dashboard
- serve static CSS and JS
- extend api helpers with queue and stats helpers
- expose new API endpoints for queue, sync and stats
- document endpoints in developer and plugin docs
- provide tests for the new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d921d94308323818838ea44f36fe4