### PR TITLE
Implement queue watcher daemon

### DIFF
--- a/ipod-watcher.service
+++ b/ipod-watcher.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=iPod sync queue watcher
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 -m ipod_sync.watcher
+WorkingDirectory=/home/pi/ipod-dock
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ipod_sync/__init__.py
+++ b/ipod_sync/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "libpod_wrapper",
     "utils",
     "sync_from_queue",
+    "watcher",
     "logging_setup",
     "templates",
 ]

--- a/ipod_sync/watcher.py
+++ b/ipod_sync/watcher.py
@@ -1,0 +1,110 @@
+"""Filesystem watcher that triggers syncing when new files arrive."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from . import config
+from .logging_setup import setup_logging
+from .sync_from_queue import sync_queue
+
+logger = logging.getLogger(__name__)
+
+
+_TEMP_SUFFIXES = (".tmp", ".swp", "~", ".part")
+
+
+def _should_ignore(path: str) -> bool:
+    """Return ``True`` if *path* should not trigger a sync."""
+    name = Path(path).name
+    return name.startswith(".") or name.endswith(_TEMP_SUFFIXES)
+
+
+class QueueEventHandler(FileSystemEventHandler):
+    """Handle filesystem events from the sync queue."""
+
+    def __init__(self, device: str, dry_run: bool = False) -> None:
+        super().__init__()
+        self.device = device
+        self.dry_run = dry_run
+
+    def _process(self, path: str) -> None:
+        if _should_ignore(path):
+            logger.debug("Ignoring temporary file %s", path)
+            return
+        logger.info("Detected new file %s", Path(path).name)
+        try:
+            if self.dry_run:
+                logger.info("Dry-run: would sync queue")
+            else:
+                sync_queue(self.device)
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            logger.error("Failed to process queue: %s", exc)
+
+    def on_created(self, event) -> None:  # noqa: D401
+        if not event.is_directory:
+            self._process(event.src_path)
+
+    def on_moved(self, event) -> None:  # noqa: D401
+        if not event.is_directory:
+            self._process(event.dest_path)
+
+    def on_closed(self, event) -> None:  # noqa: D401
+        if not event.is_directory:
+            self._process(event.src_path)
+
+
+def watch(queue_dir: Path, device: str, dry_run: bool = False) -> None:
+    """Start watching *queue_dir* for new files."""
+    queue_dir = Path(queue_dir)
+    queue_dir.mkdir(parents=True, exist_ok=True)
+
+    handler = QueueEventHandler(device, dry_run=dry_run)
+    observer = Observer()
+    observer.schedule(handler, str(queue_dir), recursive=False)
+    observer.start()
+    logger.info("Watching %s", queue_dir)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("Stopping watcher")
+    finally:
+        observer.stop()
+        observer.join()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Watch a directory and sync files to an iPod"
+    )
+    parser.add_argument(
+        "--queue-dir",
+        default=config.SYNC_QUEUE_DIR,
+        type=Path,
+        help="Directory containing queued files",
+    )
+    parser.add_argument(
+        "--device",
+        default=config.IPOD_DEVICE,
+        help="Path to iPod block device",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log events without syncing",
+    )
+    args = parser.parse_args(argv)
+
+    setup_logging()
+    watch(args.queue_dir, args.device, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,30 @@
+import logging
+from pathlib import Path
+from unittest import mock
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ipod_sync.watcher as watcher
+
+
+def _event(path: Path):
+    return mock.Mock(src_path=str(path), dest_path=str(path), is_directory=False)
+
+
+def test_created_event_triggers_sync():
+    handler = watcher.QueueEventHandler("/dev/ipod")
+    event = _event(Path("/queue/foo.mp3"))
+    with mock.patch.object(watcher, "sync_queue") as mock_sync:
+        handler.on_created(event)
+        mock_sync.assert_called_once_with("/dev/ipod")
+
+
+def test_sync_exception_logged(caplog):
+    handler = watcher.QueueEventHandler("/dev/ipod")
+    event = _event(Path("/queue/foo.mp3"))
+    with mock.patch.object(watcher, "sync_queue", side_effect=RuntimeError("boom")):
+        with caplog.at_level(logging.ERROR):
+            handler.on_created(event)
+        assert "boom" in caplog.text


### PR DESCRIPTION
## Summary
- add `ipod_sync.watcher` module to watch the queue and trigger syncing
- expose watcher in package `__all__`
- provide `ipod-watcher.service` for running via systemd
- test watcher event handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d971550488323ab38c6c368cb81a9