### PR TITLE
Add systemd unit for API server

### DIFF
--- a/ipod-api.service
+++ b/ipod-api.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=iPod FastAPI server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/ipod-dock
+ExecStart=/usr/bin/python3 -m ipod_sync.app
+Restart=on-failure
+User=pi
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- provide a systemd service file `ipod-api.service` for running the FastAPI server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d9a8ea7f8832397c570b2d2dac91d