### PR TITLE
Add watcher tests and update systemd service

### DIFF
--- a/ipod-watcher.service
+++ b/ipod-watcher.service
@@ -5,8 +5,10 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/python3 -m ipod_sync.watcher
-WorkingDirectory=/home/pi/ipod-dock
-Restart=always
+WorkingDirectory=/path/to/ipod-dock
+Restart=on-failure
+User=pi
+Environment=PYTHONUNBUFFERED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -28,3 +28,20 @@ def test_sync_exception_logged(caplog):
         with caplog.at_level(logging.ERROR):
             handler.on_created(event)
         assert "boom" in caplog.text
+
+
+def test_should_ignore_temp_and_hidden_files():
+    assert watcher._should_ignore("/path/.hidden")
+    assert watcher._should_ignore("/path/foo.tmp")
+    assert watcher._should_ignore("/path/foo.swp")
+    assert watcher._should_ignore("/path/foo~")
+    assert watcher._should_ignore("/path/foo.part")
+    assert not watcher._should_ignore("/path/foo.mp3")
+
+
+def test_ignored_event_does_not_sync():
+    handler = watcher.QueueEventHandler("/dev/ipod")
+    event = _event(Path("/queue/.foo.swp"))
+    with mock.patch.object(watcher, "sync_queue") as mock_sync:
+        handler.on_created(event)
+        mock_sync.assert_not_called()


### PR DESCRIPTION
## Summary
- extend watcher unit tests for more coverage
- adjust `ipod-watcher.service` to point at the watcher module and set restart policy

## Testing
- `pytest -q`
- `systemd-analyze verify ipod-watcher.service`


------
https://chatgpt.com/codex/tasks/task_e_684d9b656ce483238949bb1b59b30c33