### PR TITLE
Add installer for dependencies and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ See [research.md](research.md) for notes on the hardware setup and [roadmap.md](
 
 ## Setup
 
-Install the required system packages (on Raspberry Pi OS):
+A helper script `install.sh` automates dependency installation and sets up the
+systemd service units. Run it from the project root:
+
+```bash
+./install.sh
+```
+
+If you prefer to perform the steps manually, install the required system
+packages (on Raspberry Pi OS):
 
 ```bash
 sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Simple installer for ipod-dock dependencies and services
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Install system packages
+if command -v apt-get >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y python3-gpod libgpod-common ffmpeg python3-venv
+fi
+
+# Create virtual environment
+if [ ! -d "$PROJECT_DIR/.venv" ]; then
+    python3 -m venv "$PROJECT_DIR/.venv"
+fi
+source "$PROJECT_DIR/.venv/bin/activate"
+
+# Install Python packages
+pip install -U pip fastapi uvicorn watchdog httpx python-multipart
+
+# Install systemd services if available
+if command -v systemctl >/dev/null; then
+    for svc in ipod-api.service ipod-watcher.service; do
+        tmp=$(mktemp)
+        sed "s|/path/to/ipod-dock|$PROJECT_DIR|" "$PROJECT_DIR/$svc" > "$tmp"
+        sudo mv "$tmp" "/etc/systemd/system/$svc"
+    done
+    sudo systemctl daemon-reload
+    sudo systemctl enable ipod-api.service ipod-watcher.service
+    echo "Services installed. Start them with:\n sudo systemctl start ipod-api.service ipod-watcher.service"
+fi
+


### PR DESCRIPTION
## Summary
- add `install.sh` helper script to install packages and systemd services
- document the new script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9c9ea50c8323b4d44ce4664db180