### PR TITLE
Add playlist creation support

### DIFF
--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -6,7 +6,12 @@ import logging
 from pathlib import Path
 
 from . import config
-from .libpod_wrapper import list_tracks, delete_track
+from .libpod_wrapper import (
+    list_tracks,
+    delete_track,
+    list_playlists,
+    create_playlist,
+)
 from .utils import mount_ipod, eject_ipod
 
 logger = logging.getLogger(__name__)
@@ -59,11 +64,29 @@ def get_tracks(device: str = config.IPOD_DEVICE) -> list[dict]:
         eject_ipod()
 
 
+def get_playlists(device: str = config.IPOD_DEVICE) -> list[dict]:
+    """Mount the iPod and return a list of playlists."""
+    mount_ipod(device)
+    try:
+        return list_playlists()
+    finally:
+        eject_ipod()
+
+
 def remove_track(db_id: str, device: str = config.IPOD_DEVICE) -> None:
     """Delete a track from the iPod by its database ID."""
     mount_ipod(device)
     try:
         delete_track(db_id)
+    finally:
+        eject_ipod()
+
+
+def create_new_playlist(name: str, track_ids: list[str], device: str = config.IPOD_DEVICE) -> None:
+    """Create a playlist with ``track_ids`` on the iPod."""
+    mount_ipod(device)
+    try:
+        create_playlist(name, track_ids)
     finally:
         eject_ipod()
 

--- a/ipod_sync/static/style.css
+++ b/ipod_sync/static/style.css
@@ -238,6 +238,9 @@ body {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
     transition: all 0.3s ease;
     border-left: 4px solid #667eea;
+    display: flex;
+    gap: 10px;
+    align-items: center;
 }
 
 .track-item:hover {
@@ -247,6 +250,10 @@ body {
 
 .track-item.audiobook {
     border-left-color: #ff7e5f;
+}
+
+.select-box {
+    margin-right: 5px;
 }
 
 .track-title {

--- a/ipod_sync/templates/index.html
+++ b/ipod_sync/templates/index.html
@@ -57,9 +57,14 @@
                     <div class="tab active" onclick="switchTab('music', this)">🎵 Music</div>
                     <div class="tab" onclick="switchTab('audiobooks', this)">📚 Audiobooks</div>
                     <div class="tab" onclick="switchTab('queue', this)">⏳ Queue</div>
+                    <div class="tab" onclick="switchTab('playlists', this)">📃 Playlists</div>
                 </div>
 
                 <input type="text" class="search-bar" placeholder="🔍 Search your library..." id="search-input">
+
+                <div style="margin-bottom: 10px;">
+                    <button class="btn" onclick="openPlaylistDialog()">➕ Create Playlist</button>
+                </div>
 
                 <div class="track-grid" id="track-grid">
                 </div>

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -30,6 +30,17 @@ def test_get_tracks_mounts_and_ejects(mock_mount, mock_eject, mock_list):
     assert tracks == [{"id": "1"}]
 
 
+@mock.patch("ipod_sync.api_helpers.list_playlists")
+@mock.patch("ipod_sync.api_helpers.eject_ipod")
+@mock.patch("ipod_sync.api_helpers.mount_ipod")
+def test_get_playlists_calls_lib(mock_mount, mock_eject, mock_list):
+    mock_list.return_value = [{"name": "Mix"}]
+    pls = api_helpers.get_playlists("/dev/ipod")
+    mock_mount.assert_called_once_with("/dev/ipod")
+    mock_eject.assert_called_once()
+    assert pls == [{"name": "Mix"}]
+
+
 @mock.patch("ipod_sync.api_helpers.delete_track")
 @mock.patch("ipod_sync.api_helpers.eject_ipod")
 @mock.patch("ipod_sync.api_helpers.mount_ipod")
@@ -62,3 +73,13 @@ def test_get_stats_uses_shutil(mock_queue, mock_tracks, tmp_path):
     assert stats["music"] == 1
     assert stats["queue"] == 1
     assert stats["storage_used"] == 25
+
+
+@mock.patch("ipod_sync.api_helpers.create_playlist")
+@mock.patch("ipod_sync.api_helpers.eject_ipod")
+@mock.patch("ipod_sync.api_helpers.mount_ipod")
+def test_create_new_playlist(mock_mount, mock_eject, mock_create):
+    api_helpers.create_new_playlist("Mix", ["1"], "/dev/ipod")
+    mock_mount.assert_called_once_with("/dev/ipod")
+    mock_create.assert_called_once_with("Mix", ["1"])
+    mock_eject.assert_called_once()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -72,6 +72,22 @@ def test_delete_track_not_found(mock_remove):
     mock_remove.assert_called_once_with("99", app_module.config.IPOD_DEVICE)
 
 
+@mock.patch.object(app_module, "get_playlists", return_value=[{"name": "Mix"}])
+def test_playlists_get(mock_get):
+    response = client.get("/playlists")
+    assert response.status_code == 200
+    assert response.json() == [{"name": "Mix"}]
+    mock_get.assert_called_once_with(app_module.config.IPOD_DEVICE)
+
+
+@mock.patch.object(app_module, "create_new_playlist")
+def test_playlists_post(mock_create):
+    response = client.post("/playlists", json={"name": "Mix", "tracks": ["1"]})
+    assert response.status_code == 200
+    assert response.json() == {"created": "Mix"}
+    mock_create.assert_called_once_with("Mix", ["1"], app_module.config.IPOD_DEVICE)
+
+
 @mock.patch.object(app_module, "list_queue", return_value=[{"name": "a.mp3"}])
 def test_queue_endpoint(mock_list):
     response = client.get("/queue")


### PR DESCRIPTION
## Summary
- wrap libgpod playlist helpers
- expose playlist helpers via API
- add `/playlists` GET/POST endpoints
- extend web UI to create playlists from selected tracks
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc77264e48323970bdd619b1398d8