### PR TITLE
Increase coverage for podcast features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 logs/
 uploads/
 sync_queue/
+.coverage

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -130,6 +130,20 @@ def test_podcasts_fetch_endpoint(mock_fetcher):
     mock_fetcher.fetch_podcasts.assert_called_once_with("http://f")
 
 
+def test_podcasts_fetch_missing_url():
+    response = client.post("/podcasts/fetch", json={})
+    assert response.status_code == 400
+
+
+@mock.patch.object(app_module, "podcast_fetcher")
+def test_podcasts_fetch_error(mock_fetcher):
+    mock_fetcher.fetch_podcasts.side_effect = RuntimeError("boom")
+    response = client.post("/podcasts/fetch", json={"feed_url": "http://f"})
+    assert response.status_code == 500
+    assert "boom" in response.text
+    mock_fetcher.fetch_podcasts.assert_called_once_with("http://f")
+
+
 @mock.patch.object(app_module, "get_stats", return_value={"music": 1})
 def test_stats_endpoint(mock_stats):
     response = client.get("/stats")

--- a/tests/test_podcast_fetcher.py
+++ b/tests/test_podcast_fetcher.py
@@ -18,3 +18,27 @@ def test_fetch_podcasts_downloads(tmp_path):
             downloaded = podcast_fetcher.fetch_podcasts("http://feed", tmp_path)
     assert (tmp_path / "ep.mp3").exists()
     assert downloaded == [tmp_path / "ep.mp3"]
+
+
+def test_fetch_podcasts_ignores_missing_href(tmp_path):
+    feed = mock.Mock(entries=[
+        mock.Mock(enclosures=[{"length": 123}])
+    ])
+    with mock.patch.object(podcast_fetcher.feedparser, "parse", return_value=feed):
+        with mock.patch("urllib.request.urlretrieve") as urlret:
+            downloaded = podcast_fetcher.fetch_podcasts("http://feed", tmp_path)
+    urlret.assert_not_called()
+    assert downloaded == []
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_podcasts_skips_existing_file(tmp_path):
+    (tmp_path / "ep.mp3").write_bytes(b"old")
+    feed = mock.Mock(entries=[
+        mock.Mock(enclosures=[{"href": "http://example.com/ep.mp3"}])
+    ])
+    with mock.patch.object(podcast_fetcher.feedparser, "parse", return_value=feed):
+        with mock.patch("urllib.request.urlretrieve") as urlret:
+            downloaded = podcast_fetcher.fetch_podcasts("http://feed", tmp_path)
+    urlret.assert_not_called()
+    assert downloaded == []


### PR DESCRIPTION
## Summary
- ignore `.coverage` artifacts
- expand `podcast_fetcher` tests for missing `href` and skipped downloads
- expand `/podcasts/fetch` endpoint tests for missing `feed_url` and for exception paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dd134df748323a29481c0f47e97b1