### PR TITLE
Install automake for libgpod build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If your distribution does not provide the `python3-gpod` package, running
-`install.sh` will automatically build the libgpod bindings from source.
+`install.sh` will automatically build the libgpod bindings from source and
+install build tools such as `automake`.
 
 Create a Python virtual environment in the project root:
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -27,7 +27,7 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If the `python3-gpod` package is missing, run `../install.sh` which will
-compile the libgpod bindings automatically.
+compile the libgpod bindings automatically and install tools like `automake`.
 
 ## Running the services
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,8 @@ sudo apt-get install libgpod-common
 ```
 
 If `python3-gpod` isn't packaged on your system, the `install.sh` script will
-download and build the bindings automatically.
+download and build the bindings automatically and install required build tools
+such as `automake`.
 
 The module exposes three simple helpers:
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ SERVICE_USER="ipod"
 build_libgpod() {
     echo "Building libgpod from source..."
     sudo apt-get install -y build-essential git libtool intltool \
+        autoconf automake \
         libglib2.0-dev libimobiledevice-dev libplist-dev python3-dev
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"


### PR DESCRIPTION
## Summary
- ensure `install.sh` installs automake when building libgpod
- update docs to mention automake requirement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eff2cca688323a296b97dcd3582c0