### PR TITLE
Improve install script automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ systemd service units. Run it from the project root:
 ./install.sh
 ```
 
-The installer creates a dedicated `ipod` user and installs the unit files under
-`/etc/systemd/system`. Start the services with:
+The installer creates a dedicated `ipod` user, installs the unit files under
+`/etc/systemd/system` and sets up a Python virtual environment in `.venv` with
+all packages from `requirements.txt`. Start the services with:
 
 ```bash
 sudo systemctl start ipod-api.service ipod-watcher.service
@@ -56,6 +57,7 @@ Create a Python virtual environment in the project root:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
+pip install -r requirements.txt
 ```
 
 This repository will use the virtual environment for any Python tools and future dependencies.

--- a/install.sh
+++ b/install.sh
@@ -7,16 +7,23 @@ SERVICE_USER="ipod"
 
 build_libgpod() {
     echo "Building libgpod from source..."
-    sudo apt-get install -y build-essential git libtool intltool \
+    sudo apt-get install -y build-essential git libtool intltool gtk-doc-tools \
         autoconf automake \
         libglib2.0-dev libimobiledevice-dev libplist-dev python3-dev
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null
-    ./autogen.sh
+    export AUTOMAKE=automake
+    export ACLOCAL=aclocal
+    pcdir=$(pkg-config --variable=pcfiledir libplist-2.0 2>/dev/null || true)
+    if [ -n "$pcdir" ] && [ ! -e "$pcdir/libplist.pc" ] && [ -e "$pcdir/libplist-2.0.pc" ]; then
+        sudo ln -s "$pcdir/libplist-2.0.pc" "$pcdir/libplist.pc"
+    fi
+    autoreconf -fvi
     ./configure --with-python3
     make
     sudo make install
+    sudo ldconfig
     popd >/dev/null
     rm -rf "$workdir"
 }
@@ -38,7 +45,8 @@ fi
 source "$PROJECT_DIR/.venv/bin/activate"
 
 # Install Python packages
-pip install -U pip fastapi uvicorn watchdog httpx python-multipart
+pip install -U pip
+pip install -r "$PROJECT_DIR/requirements.txt"
 
 # Ensure dedicated service user exists
 if ! id "$SERVICE_USER" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- fully automate environment setup in `install.sh`
- describe how the installer sets up the environment
- document manual dependency install
- fix libgpod build by adding gtk-doc-tools
- fix autogen failure when building libgpod

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f025abdd8832399cda213f54d89a6