### PR TITLE
Fix libgpod build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If your distribution does not provide the `python3-gpod` package, running
-`install.sh` will automatically build the libgpod bindings from source and
-install build tools such as `automake`.
+`install.sh` will build the libgpod bindings from source. This requires the
+SQLite development headers which can be installed with:
+
+```bash
+sudo apt-get install libsqlite3-dev
+```
+
+The script also installs other build tools such as `automake`.
 
 Create a Python virtual environment in the project root:
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -26,8 +26,9 @@ System packages for the iPod bindings and `ffmpeg` can be installed on Debian ba
 sudo apt-get install libgpod-common ffmpeg
 ```
 
-If the `python3-gpod` package is missing, run `../install.sh` which will
-compile the libgpod bindings automatically and install tools like `automake`.
+If the `python3-gpod` package is missing, run `../install.sh` to build the
+libgpod bindings from source. The build requires the SQLite development headers
+(`libsqlite3-dev`) and installs other tools like `automake`.
 
 ## Running the services
 

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,8 @@ build_libgpod() {
     echo "Building libgpod from source..."
     sudo apt-get install -y build-essential git libtool intltool gtk-doc-tools \
         autoconf automake \
-        libglib2.0-dev libimobiledevice-dev libplist-dev python3-dev
+        libglib2.0-dev libimobiledevice-dev libplist-dev python3-dev \
+        libsqlite3-dev
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null


### PR DESCRIPTION
## Summary
- add libsqlite3-dev to install script so libgpod configure succeeds
- document that sqlite headers are needed when building from source

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2ed3adf88323bd43d31ff5ee4404