### PR TITLE
Add libxml2-dev requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ sudo apt-get install libgpod-common ffmpeg
 
 If your distribution does not provide the `python3-gpod` package, running
 `install.sh` will build the libgpod bindings from source. This requires the
-SQLite development headers which can be installed with:
+SQLite development headers and libxml2 development files which can be installed
+with:
 
 ```bash
-sudo apt-get install libsqlite3-dev
+sudo apt-get install libsqlite3-dev libxml2-dev
 ```
 
 The script also installs other build tools such as `automake`.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -28,7 +28,8 @@ sudo apt-get install libgpod-common ffmpeg
 
 If the `python3-gpod` package is missing, run `../install.sh` to build the
 libgpod bindings from source. The build requires the SQLite development headers
-(`libsqlite3-dev`) and installs other tools like `automake`.
+(`libsqlite3-dev`) and the libxml2 development package (`libxml2-dev`). The
+script also installs other tools like `automake`.
 
 ## Running the services
 

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,8 @@ build_libgpod() {
     echo "Building libgpod from source..."
     sudo apt-get install -y build-essential git libtool intltool gtk-doc-tools \
         autoconf automake \
-        libglib2.0-dev libimobiledevice-dev libplist-dev python3-dev \
-        libsqlite3-dev
+        libglib2.0-dev libimobiledevice-dev libplist-dev libxml2-dev \
+        python3-dev libsqlite3-dev
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null


### PR DESCRIPTION
## Summary
- document libxml2-dev dependency
- update developer guide for build requirements
- add libxml2-dev to installer script

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f30f3d6108323b58272b46b80c9d9