### PR TITLE
Patch libgpod during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,11 @@ build_libgpod() {
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null
+    # Apply patches for newer GLib and compiler warnings
+    sed -i 's/g_memdup (/g_memdup2 (/g' src/db-artwork-parser.c
+    sed -i 's/GList \*artwork_glist = NULL;/GList **artwork_list = NULL;/' src/db-artwork-parser.c
+    sed -i '/ctx->db->db_type == DB_TYPE_ITUNES)/,/ctx->artwork =/s/ctx->artwork = &artwork_glist;/artwork_list = g_new0 (GList *, 1);\n            ctx->artwork = artwork_list;/' src/db-artwork-parser.c
+    sed -i '/g_list_free (\*ctx->artwork);/a\    g_free (ctx->artwork);' src/db-artwork-parser.c
     export AUTOMAKE=automake
     export ACLOCAL=aclocal
     pcdir=$(pkg-config --variable=pcfiledir libplist-2.0 2>/dev/null || true)
@@ -21,7 +26,8 @@ build_libgpod() {
         sudo ln -s "$pcdir/libplist-2.0.pc" "$pcdir/libplist.pc"
     fi
     autoreconf -fvi
-    ./configure --with-python3
+    CFLAGS="-Wno-error=deprecated-declarations -Wno-error=dangling-pointer" \
+        ./configure --with-python3
     make
     sudo make install
     sudo ldconfig


### PR DESCRIPTION
## Summary
- patch `src/db-artwork-parser.c` when building libgpod
- allow deprecated declarations in CFLAGS
- fix sed commands to properly modify libgpod source

## Testing
- `shellcheck install.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f35d9c3548323b6f897e02a4b6c29