### PR TITLE
Switch to john8675309 libgpod fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If your distribution does not provide the `python3-gpod` package, running
-`install.sh` will build the libgpod bindings from source. This requires the
-SQLite development headers and libxml2 development files which can be installed
-with:
+`install.sh` will build the libgpod bindings from a maintained fork
+([`john8675309/libgpod-0.8.3`](https://github.com/john8675309/libgpod-0.8.3))
+with Python 3 support. This requires the SQLite development headers and libxml2
+development files which can be installed with:
 
 ```bash
 sudo apt-get install libsqlite3-dev libxml2-dev

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -27,7 +27,8 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If the `python3-gpod` package is missing, run `../install.sh` to build the
-libgpod bindings from source. The build requires the SQLite development headers
+libgpod bindings from the [`john8675309/libgpod-0.8.3`](https://github.com/john8675309/libgpod-0.8.3)
+fork with Python 3 support. The build requires the SQLite development headers
 (`libsqlite3-dev`) and the libxml2 development package (`libxml2-dev`). The
 script also installs other tools like `automake`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,8 +38,9 @@ sudo apt-get install libgpod-common
 ```
 
 If `python3-gpod` isn't packaged on your system, the `install.sh` script will
-download and build the bindings automatically and install required build tools
-such as `automake`.
+download and build the bindings from the
+[`john8675309/libgpod-0.8.3`](https://github.com/john8675309/libgpod-0.8.3)
+fork and install required build tools such as `automake`.
 
 The module exposes three simple helpers:
 

--- a/install.sh
+++ b/install.sh
@@ -12,22 +12,16 @@ build_libgpod() {
         libglib2.0-dev libimobiledevice-dev libplist-dev libxml2-dev \
         python3-dev libsqlite3-dev
     workdir=$(mktemp -d)
-    git clone --depth 1 https://github.com/fadingred/libgpod "$workdir/libgpod"
+    git clone --depth 1 https://github.com/john8675309/libgpod-0.8.3.git "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null
-    # Apply patches for newer GLib and compiler warnings
-    sed -i 's/g_memdup (/g_memdup2 (/g' src/db-artwork-parser.c
-    sed -i 's/^\(GList \*\)artwork_glist = NULL;/GList **artwork_list = NULL;/' src/db-artwork-parser.c
-    sed -i '/ctx->db->db_type == DB_TYPE_ITUNES)/,/ctx->artwork =/s/ctx->artwork = &artwork_glist;/artwork_list = g_new0 (GList *, 1);\n            ctx->artwork = artwork_list;/' src/db-artwork-parser.c
-    sed -i '/g_list_free (*ctx->artwork);/a\    g_free (ctx->artwork);' src/db-artwork-parser.c
     export AUTOMAKE=automake
     export ACLOCAL=aclocal
     pcdir=$(pkg-config --variable=pcfiledir libplist-2.0 2>/dev/null || true)
     if [ -n "$pcdir" ] && [ ! -e "$pcdir/libplist.pc" ] && [ -e "$pcdir/libplist-2.0.pc" ]; then
         sudo ln -s "$pcdir/libplist-2.0.pc" "$pcdir/libplist.pc"
     fi
-    autoreconf -fvi
-    CFLAGS="-Wno-error=deprecated-declarations -Wno-error=dangling-pointer" \
-        ./configure --with-python3
+    ./autogen.sh
+    ./configure --with-python3
     make
     sudo make install
     sudo ldconfig


### PR DESCRIPTION
## Summary
- build libgpod from the john8675309 fork instead of patching the original
- document that install.sh uses the maintained fork

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f39dde2a4832393162d32be22fddb