### PR TITLE
Fix systemd service working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ systemd service units. Run it from the project root:
 
 The installer creates a dedicated `ipod` user, installs the unit files under
 `/etc/systemd/system` and sets up a Python virtual environment in `.venv` with
-all packages from `requirements.txt`. Start the services with:
+all packages from `requirements.txt`. The service units use the `ipod` user's
+home directory as the working directory, so the installer also adjusts
+ownership of the project folder. Start the services with:
 
 ```bash
 sudo systemctl start ipod-api.service ipod-watcher.service

--- a/install.sh
+++ b/install.sh
@@ -52,12 +52,14 @@ pip install -r "$PROJECT_DIR/requirements.txt"
 if ! id "$SERVICE_USER" >/dev/null 2>&1; then
     sudo useradd -r -s /usr/sbin/nologin -d "$PROJECT_DIR" "$SERVICE_USER"
 fi
+# Ensure service user can access the project directory
+sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$PROJECT_DIR"
 
 # Install systemd services if available
 if command -v systemctl >/dev/null; then
     for svc in ipod-api.service ipod-watcher.service; do
         tmp=$(mktemp)
-        sed "s|/path/to/ipod-dock|$PROJECT_DIR|; s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
+        sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
     sudo systemctl daemon-reload

--- a/ipod-api.service
+++ b/ipod-api.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/path/to/ipod-dock
+WorkingDirectory=%h
 ExecStart=/usr/bin/python3 -m ipod_sync.app
 Restart=on-failure
 User=ipod

--- a/ipod-watcher.service
+++ b/ipod-watcher.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/python3 -m ipod_sync.watcher
-WorkingDirectory=/path/to/ipod-dock
+WorkingDirectory=%h
 Restart=on-failure
 User=ipod
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- ensure service uses `%h` for working directory
- chown project directory for service user and simplify sed replacement
- note working directory behaviour in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4766df8483239a9f535ac88f9082