### PR TITLE
Fix service working directory

### DIFF
--- a/ipod-api.service
+++ b/ipod-api.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=%h
+WorkingDirectory=/opt/ipod-dock
 ExecStart=/usr/bin/python3 -m ipod_sync.app
 Restart=on-failure
 User=ipod

--- a/ipod-watcher.service
+++ b/ipod-watcher.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/python3 -m ipod_sync.watcher
-WorkingDirectory=%h
+WorkingDirectory=/opt/ipod-dock
 Restart=on-failure
 User=ipod
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- set explicit working directory for ipod-api and ipod-watcher services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fce52603c832396afdb452cfb06ab