### PR TITLE
Improve sync error handling

### DIFF
--- a/ipod_sync/static/app.js
+++ b/ipod_sync/static/app.js
@@ -233,12 +233,20 @@ async function syncNow() {
 
     statusIndicator.className = 'status-indicator status-syncing';
     statusText.textContent = 'Syncing...';
-    await fetch('/sync', { method: 'POST' });
-    await updateStats();
-    statusIndicator.className = 'status-indicator status-connected';
-    statusText.textContent = 'iPod Connected';
-    document.getElementById('last-sync').textContent = new Date().toLocaleTimeString();
-    showNotification('Sync completed successfully!', 'success');
+    try {
+        const res = await fetch('/sync', { method: 'POST' });
+        if (!res.ok) throw new Error('Sync failed');
+        await updateStats();
+        statusIndicator.className = 'status-indicator status-connected';
+        statusText.textContent = 'iPod Connected';
+        document.getElementById('last-sync').textContent = new Date().toLocaleTimeString();
+        showNotification('Sync completed successfully!', 'success');
+    } catch (err) {
+        console.error(err);
+        statusIndicator.className = 'status-indicator status-error';
+        statusText.textContent = 'Sync failed';
+        showNotification('Sync failed', 'error');
+    }
 }
 
 async function clearQueue() {


### PR DESCRIPTION
## Summary
- catch exceptions in `/sync` endpoint to avoid hanging UI
- report errors in UI when sync request fails
- test sync error handling

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850629b6e28832392720b1a7b5af4a6