### PR TITLE
Fix user mount command

### DIFF
--- a/ipod_sync/utils.py
+++ b/ipod_sync/utils.py
@@ -50,7 +50,13 @@ def mount_ipod(device: str) -> None:
     mount_point: Path = IPOD_MOUNT
     mount_point.mkdir(parents=True, exist_ok=True)
     logger.info("Mounting %s at %s", device, mount_point)
-    _run(["mount", device, str(mount_point)])
+    # When ``user`` mount permissions are configured in ``/etc/fstab`` a
+    # non-root user may only specify one of the mount point **or** device
+    # name. Passing both causes ``mount`` to abort with "must be superuser"
+    # even if the user is permitted to mount the device. Using only the
+    # mount point relies on the ``fstab`` entry to look up the device and
+    # works correctly for unprivileged users.
+    _run(["mount", str(mount_point)])
 
 
 def eject_ipod() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ def test_mount_ipod_calls_mount(mock_run, tmp_path):
     with mock.patch.object(utils, "IPOD_MOUNT", mount_point):
         utils.mount_ipod(device)
         mock_run.assert_called_with(
-            ["mount", device, str(mount_point)],
+            ["mount", str(mount_point)],
             check=True,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- fix mounting logic for non-root users
- update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68507abf2edc832386c8d711c46d853a