### PR TITLE
Add device connection status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ See [research.md](research.md) for notes on the hardware setup and [wiring instr
   `ffmpeg` before import.
 - **FastAPI web API** providing upload, track management and statistics
   endpoints.
+- **Connection status indicator** via the `/status` endpoint to show whether the
+  iPod is connected.
 - **HTML dashboard** served by the API for manual uploads and browsing the
   library.
 - **Watcher daemon** using `watchdog` to trigger syncing when new files appear in
@@ -158,6 +160,9 @@ python -m ipod_sync.app
 
 With the server running, navigate to `http://localhost:8000/` (or use the Pi's
 address) to use the HTML dashboard for uploads and track browsing.
+
+The `/status` endpoint now reports whether the configured iPod device is
+connected via a `connected` boolean field.
 
 See [docs/development.md](docs/development.md) for the list of endpoints.
 Plugin developers can find usage examples in

--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -17,6 +17,22 @@ from .utils import mount_ipod, eject_ipod
 logger = logging.getLogger(__name__)
 
 
+def is_ipod_connected(device: str = config.IPOD_DEVICE) -> bool:
+    """Return ``True`` if the iPod device exists or is mounted."""
+    dev = Path(device)
+    if dev.exists():
+        return True
+    try:
+        with open("/proc/mounts", "r", encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.split()
+                if parts and parts[0] == str(device):
+                    return True
+    except Exception:  # pragma: no cover - platform specific failures
+        return False
+    return False
+
+
 def save_to_queue(
     name: str,
     data: bytes,

--- a/ipod_sync/app.py
+++ b/ipod_sync/app.py
@@ -22,6 +22,7 @@ from .api_helpers import (
     get_stats,
     get_playlists,
     create_new_playlist,
+    is_ipod_connected,
 )
 from . import sync_from_queue, podcast_fetcher
 
@@ -47,7 +48,8 @@ async def index() -> str:
 async def status() -> dict:
     """Return service health information."""
     logger.debug("Status check")
-    return {"status": "ok"}
+    connected = is_ipod_connected(config.IPOD_DEVICE)
+    return {"status": "ok", "connected": connected}
 
 
 @app.post("/upload", dependencies=[auth_dep])

--- a/ipod_sync/static/app.js
+++ b/ipod_sync/static/app.js
@@ -19,6 +19,8 @@ async function initializeApp() {
     try {
         await loadTracks();
         await updateStats();
+        await checkDeviceStatus();
+        setInterval(checkDeviceStatus, 30000);
     } catch (err) {
         console.error('Initialization failed', err);
     }
@@ -239,6 +241,26 @@ async function updateStats() {
     }
     document.getElementById('storage-used').textContent = stats.storage_used + '%';
     document.getElementById('sync-queue').textContent = stats.queue;
+}
+
+async function checkDeviceStatus() {
+    const statusIndicator = document.getElementById('status-indicator');
+    const statusText = document.getElementById('status-text');
+    try {
+        const res = await authFetch('/status');
+        const data = await res.json();
+        if (data.connected) {
+            statusIndicator.className = 'status-indicator status-connected';
+            statusText.textContent = 'iPod Connected';
+        } else {
+            statusIndicator.className = 'status-indicator status-disconnected';
+            statusText.textContent = 'iPod Disconnected';
+        }
+    } catch (err) {
+        console.error(err);
+        statusIndicator.className = 'status-indicator status-error';
+        statusText.textContent = 'Status Error';
+    }
 }
 
 async function syncNow() {

--- a/ipod_sync/static/style.css
+++ b/ipod_sync/static/style.css
@@ -308,6 +308,10 @@ body {
     background: #4CAF50;
 }
 
+.status-disconnected {
+    background: #ccc;
+}
+
 .status-syncing {
     background: #FF9800;
     animation: pulse 1.5s infinite;

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -64,6 +64,25 @@ def test_list_and_clear_queue(tmp_path):
     assert not any(tmp_path.iterdir())
 
 
+def test_is_ipod_connected_exists(tmp_path):
+    dev = tmp_path / "sda1"
+    dev.write_bytes(b"")
+    assert api_helpers.is_ipod_connected(str(dev))
+
+
+def test_is_ipod_connected_mounts(monkeypatch):
+    data = "/dev/foo /mnt/ipod vfat rw 0 0\n"
+    m = mock.mock_open(read_data=data)
+    monkeypatch.setattr("builtins.open", m)
+    assert api_helpers.is_ipod_connected("/dev/foo")
+
+
+def test_is_ipod_connected_false(monkeypatch):
+    m = mock.mock_open(read_data="/dev/bar /mnt xfs rw 0 0\n")
+    monkeypatch.setattr("builtins.open", m)
+    assert not api_helpers.is_ipod_connected("/dev/foo")
+
+
 @mock.patch("ipod_sync.api_helpers.get_tracks", return_value=[{"id": "1"}])
 @mock.patch("ipod_sync.api_helpers.list_queue", return_value=[{"name": "f"}])
 def test_get_stats_uses_shutil(mock_queue, mock_tracks, tmp_path):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,14 +12,16 @@ import ipod_sync.app as app_module
 client = TestClient(app)
 
 
-def test_status_endpoint():
+def test_status_endpoint(monkeypatch):
+    monkeypatch.setattr(app_module, "is_ipod_connected", lambda *_: True)
     response = client.get("/status")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json() == {"status": "ok", "connected": True}
 
 
 def test_auth_required_when_key_set(monkeypatch):
     monkeypatch.setattr(app_module.config, "API_KEY", "secret")
+    monkeypatch.setattr(app_module, "is_ipod_connected", lambda *_: False)
     unauthorized = client.get("/status")
     assert unauthorized.status_code == 401
     ok = client.get("/status", headers={"X-API-Key": "secret"})


### PR DESCRIPTION
## Summary
- add `is_ipod_connected` helper
- report connection status from `/status`
- poll status in the frontend and update UI
- add disconnected style and periodic check
- test the new helper and status endpoint
- document connection status behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685087724270832385bcfa4df529d83b