### PR TITLE
Add pyudev USB listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ See [research.md](research.md) for notes on the hardware setup and [wiring instr
   library.
 - **Watcher daemon** using `watchdog` to trigger syncing when new files appear in
   the queue.
+- **USB listener** using `pyudev` to start syncing automatically when the iPod
+  is connected.
 - **Serial playback control** via the Apple Accessory Protocol for play/pause and
   track skipping.
 - **Rotating log files** stored under `logs/` for easy debugging.
@@ -72,7 +74,7 @@ target directory is updated accordingly. Start the services with:
 
 
 ```bash
-sudo systemctl start ipod-api.service ipod-watcher.service
+sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service
 ```
 
 The services run under the dedicated `ipod` account. This user must have

--- a/install.sh
+++ b/install.sh
@@ -80,13 +80,13 @@ fi
 
 # Install systemd services if available
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
         tmp=$(mktemp)
         sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
     sudo systemctl daemon-reload
-    sudo systemctl enable ipod-api.service ipod-watcher.service
-    echo "Services installed. Start them with:\n  sudo systemctl start ipod-api.service ipod-watcher.service"
+    sudo systemctl enable ipod-api.service ipod-watcher.service ipod-listener.service
+    echo "Services installed. Start them with:\n  sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service"
 fi
 

--- a/ipod-listener.service
+++ b/ipod-listener.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=iPod USB listener
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/ipod-dock/.venv/bin/python -m ipod_sync.udev_listener
+WorkingDirectory=/opt/ipod-dock
+Restart=on-failure
+User=ipod
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target

--- a/ipod_sync/__init__.py
+++ b/ipod_sync/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "utils",
     "sync_from_queue",
     "watcher",
+    "udev_listener",
     "podcast_fetcher",
     "converter",
     "logging_setup",

--- a/ipod_sync/udev_listener.py
+++ b/ipod_sync/udev_listener.py
@@ -1,0 +1,63 @@
+"""Listen for iPod USB events and trigger syncing."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Iterable, Tuple
+
+import pyudev
+
+from . import config
+from .logging_setup import setup_logging
+from .sync_from_queue import sync_queue
+
+logger = logging.getLogger(__name__)
+
+
+def listen(
+    device: str = config.IPOD_DEVICE,
+    vendor: str = "05ac",
+    product: str = "1209",
+    monitor: Iterable[Tuple[str, pyudev.Device]] | None = None,
+) -> None:
+    """Listen for matching USB device events and sync on attach."""
+    if monitor is None:
+        ctx = pyudev.Context()
+        monitor = pyudev.Monitor.from_netlink(ctx)
+        monitor.filter_by("usb")
+        monitor = iter(monitor)
+
+    logger.info("Listening for iPod USB events")
+    for action, dev in monitor:
+        if (
+            dev.get("ID_VENDOR_ID") == vendor
+            and dev.get("ID_MODEL_ID") == product
+        ):
+            serial = dev.get("ID_SERIAL_SHORT", "unknown")
+            logger.debug("Event %s for %s", action, serial)
+            if action == "add":
+                logger.info("iPod %s attached", serial)
+                try:
+                    sync_queue(device)
+                except Exception as exc:  # pragma: no cover - runtime errors
+                    logger.error("Failed to sync: %s", exc)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Listen for iPod USB events")
+    parser.add_argument(
+        "--device",
+        default=config.IPOD_DEVICE,
+        help="Path to iPod block device",
+    )
+    parser.add_argument("--vendor", default="05ac", help="USB vendor ID")
+    parser.add_argument("--product", default="1209", help="USB product ID")
+    args = parser.parse_args(argv)
+
+    setup_logging()
+    listen(args.device, args.vendor, args.product)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-multipart
 feedparser
 pytest
 pyserial
+pyudev

--- a/tests/test_udev_listener.py
+++ b/tests/test_udev_listener.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from unittest import mock
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ipod_sync.udev_listener as listener
+
+
+class FakeMonitor:
+    def __init__(self, events):
+        self._events = events
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+
+
+def _device(vendor="05ac", product="1209", serial="123"):
+    return {
+        "ID_VENDOR_ID": vendor,
+        "ID_MODEL_ID": product,
+        "ID_SERIAL_SHORT": serial,
+    }
+
+
+def test_listener_triggers_sync():
+    monitor = FakeMonitor([("add", _device())])
+    with mock.patch.object(listener, "sync_queue") as mock_sync:
+        listener.listen("/dev/ipod", "05ac", "1209", monitor=monitor)
+        mock_sync.assert_called_once_with("/dev/ipod")
+
+
+def test_listener_ignores_non_matching():
+    monitor = FakeMonitor([("add", _device(vendor="abcd"))])
+    with mock.patch.object(listener, "sync_queue") as mock_sync:
+        listener.listen("/dev/ipod", monitor=monitor)
+        mock_sync.assert_not_called()
+
+
+def test_main_parses_args(monkeypatch):
+    called = {}
+
+    def fake_listen(device, vendor, product):
+        called["args"] = (device, vendor, product)
+
+    monkeypatch.setattr(listener, "listen", fake_listen)
+    monkeypatch.setattr(listener, "setup_logging", lambda: None)
+
+    listener.main(["--device", "/dev/x", "--vendor", "1111", "--product", "2222"])
+
+    assert called["args"] == ("/dev/x", "1111", "2222")

--- a/update.sh
+++ b/update.sh
@@ -47,13 +47,13 @@ fi
 
 # Refresh systemd units and restart services
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
         tmp=$(mktemp)
         sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
     sudo systemctl daemon-reload
-    sudo systemctl restart ipod-api.service ipod-watcher.service
+    sudo systemctl restart ipod-api.service ipod-watcher.service ipod-listener.service
 fi
 
 echo "Update complete."


### PR DESCRIPTION
## Summary
- add a pyudev-based listener to trigger syncing when an iPod is attached
- bundle new ipod-listener systemd service and manage it in install/update scripts
- list the new service in README and feature list
- add pyudev to requirements
- tests for the listener

## Testing
- `pip install -q fastapi uvicorn watchdog httpx python-multipart feedparser pyserial pyudev`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b6729f0083239cb2962e592fa9a5