### PR TITLE
Update docs for Pi Zero 2W

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ipod-dock
 
-This project aims to sync an iPod Classic with a Raspberry Pi Zero W so music, podcasts and audiobooks can be uploaded over Wi-Fi.  The repository contains scripts and a web API to manage uploads, track listings and integration with an iPod dock.
+This project aims to sync an iPod Classic with a Raspberry Pi Zero 2 W so music, podcasts and audiobooks can be uploaded over Wi-Fi.  The repository contains scripts and a web API to manage uploads, track listings and integration with an iPod dock.
+The Pi Zero 2 W keeps the build compact and power efficient. If you prefer a bit
+more CPU power or the convenience of a full-size USB port, a Pi 3A+ is a good
+alternative.
 
 See [research.md](research.md) for notes on the hardware setup and [wiring instructions](docs/wiring.md) and [roadmap_v2.md](roadmap_v2.md) for planned tasks.
 

--- a/research.md
+++ b/research.md
@@ -1,5 +1,9 @@
 Integrating an iPod Classic with a Raspberry Pi Zero 2 W for Wireless Syncing
 
+The project targets the Pi Zero 2 W for its small size and low power draw. A
+Pi 3A+ is a compatible alternative if you want a faster CPU and a full‑size USB
+port.
+
 System Overview:
 
 Figure: High-level flow of the wireless syncing system. An AudioBookShelf plugin sends files over Wi-Fi to the Raspberry Pi, which then syncs them to the docked iPod Classic via USB.
@@ -223,7 +227,7 @@ Additional Tips and Example Setup
 
     Testing: Before setting up wireless transfers, test that the Pi can see and sync the iPod wired. Plug the iPod into Pi’s USB (perhaps using a micro USB OTG cable). The iPod should start charging (it will likely beep and show “Do not disconnect”). On the Pi, dmesg should show a new USB device (e.g., “sda” attached). Install gtkpod or gnupod and try adding a song manually to verify the pipeline. This ensures your wiring and library setup is correct before automating.
 
-    Performance: USB 2.0 on Pi Zero is okay for file transfers – copying a large audiobook (hundreds of MB) might take tens of seconds. The wireless part depends on your Wi-Fi network – the Pi Zero W’s Wi-Fi is decent (802.11n 2.4GHz) so it can probably receive a file as fast as the iPod can write it (iPod HDDs or flash in those models typically write a few MB/s). For audiobooks, that’s fine. Just be patient on very large syncs, and perhaps incorporate a progress indicator if using a web UI.
+    Performance: USB 2.0 on Pi Zero is okay for file transfers – copying a large audiobook (hundreds of MB) might take tens of seconds. The wireless part depends on your Wi-Fi network – the Pi Zero 2 W’s Wi-Fi is decent (802.11n 2.4 GHz) so it can probably receive a file as fast as the iPod can write it (iPod HDDs or flash in those models typically write a few MB/s). For audiobooks, that’s fine. Just be patient on very large syncs, and perhaps incorporate a progress indicator if using a web UI.
 
     Open-Source Libraries Summary:
 


### PR DESCRIPTION
## Summary
- clarify the Raspberry Pi model used by the project
- highlight Pi 3A+ as an alternative with more CPU and a full-size USB port

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9dbd1a0c8323b35346e71df14845