### PR TITLE
Track iPod connection state via udev

### DIFF
--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 
 from . import config
+
+STATUS_FILE = Path(config.IPOD_STATUS_FILE)
 from .libpod_wrapper import (
     list_tracks,
     delete_track,
@@ -18,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 
 def is_ipod_connected(device: str = config.IPOD_DEVICE) -> bool:
-    """Return ``True`` if the iPod device exists or is mounted."""
+    """Return ``True`` if the iPod appears to be connected."""
+    if STATUS_FILE.exists():
+        return True
     dev = Path(device)
     if dev.exists():
         return True

--- a/ipod_sync/config.py
+++ b/ipod_sync/config.py
@@ -11,6 +11,9 @@ LOG_DIR = PROJECT_ROOT / "logs"
 # Mount point of the iPod on the filesystem
 IPOD_MOUNT = PROJECT_ROOT / "mnt" / "ipod"
 
+# File used by the udev listener to record connection status
+IPOD_STATUS_FILE = PROJECT_ROOT / "ipod_connected"
+
 # Default block device representing the iPod. This can be overridden
 # at runtime via command line arguments to the sync script.
 IPOD_DEVICE = "/dev/sda1"

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -70,6 +70,14 @@ def test_is_ipod_connected_exists(tmp_path):
     assert api_helpers.is_ipod_connected(str(dev))
 
 
+def test_is_ipod_connected_status_file(monkeypatch, tmp_path):
+    status = tmp_path / "status"
+    status.write_text("1")
+    monkeypatch.setattr(api_helpers.config, "IPOD_STATUS_FILE", status)
+    monkeypatch.setattr(api_helpers, "STATUS_FILE", status)
+    assert api_helpers.is_ipod_connected("/dev/foo")
+
+
 def test_is_ipod_connected_mounts(monkeypatch):
     data = "/dev/foo /mnt/ipod vfat rw 0 0\n"
     m = mock.mock_open(read_data=data)


### PR DESCRIPTION
## Summary
- track connection status using a file written by the `udev_listener`
- report connection state in `is_ipod_connected`
- test status file handling in API helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685085aa4e6083238ae89e9b0d200598