### PR TITLE
Add automatic iPod partition detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ the device path in `/etc/fstab`; the default entry looks like:
 /dev/sda1 /opt/ipod-dock/mnt/ipod vfat noauto,user,uid=ipod,gid=ipod 0 0
 ```
 
+The listener service attempts to detect the correct FAT partition
+automatically when the iPod is connected.  You can override the detected
+device by passing ``--device`` to the scripts or updating
+``config.IPOD_DEVICE``.
+
 After updating `fstab` you can test with:
 
 ```bash

--- a/tests/test_udev_listener.py
+++ b/tests/test_udev_listener.py
@@ -32,6 +32,15 @@ def test_listener_triggers_sync():
         mock_sync.assert_called_once_with("/dev/ipod")
 
 
+def test_listener_auto_detects_device():
+    monitor = FakeMonitor([("add", _device())])
+    with mock.patch.object(listener.utils, "detect_ipod_device", return_value="/dev/sdx1") as det:
+        with mock.patch.object(listener, "sync_queue") as mock_sync:
+            listener.listen(None, "05ac", "1209", monitor=monitor)
+            det.assert_called_once()
+            mock_sync.assert_called_once_with("/dev/sdx1")
+
+
 def test_listener_ignores_non_matching():
     monitor = FakeMonitor([("add", _device(vendor="abcd"))])
     with mock.patch.object(listener, "sync_queue") as mock_sync:


### PR DESCRIPTION
## Summary
- detect iPod FAT partition automatically
- mount and udev listener use the new detection when device is not specified
- document automatic detection in the README
- add unit tests for detection logic and listener behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cb0d16e08323a07a733e6557d937