### PR TITLE
Add dynamic connection status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ See [research.md](research.md) for notes on the hardware setup and [wiring instr
 - **FastAPI web API** providing upload, track management and statistics
   endpoints.
 - **Connection status indicator** via the `/status` endpoint to show whether the
-  iPod is connected.
+  iPod is connected. A file named `ipod_connected` is created in the project root
+  when the iPod is mounted and removed on eject; the UI uses this to display the
+  current connection state.
 - **HTML dashboard** served by the API for manual uploads and browsing the
   library.
 - **Watcher daemon** using `watchdog` to trigger syncing when new files appear in
@@ -168,7 +170,8 @@ With the server running, navigate to `http://localhost:8000/` (or use the Pi's
 address) to use the HTML dashboard for uploads and track browsing.
 
 The `/status` endpoint now reports whether the configured iPod device is
-connected via a `connected` boolean field.
+connected via a `connected` boolean field. This value is derived from the
+`ipod_connected` file written when the device is mounted.
 
 See [docs/development.md](docs/development.md) for the list of endpoints.
 Plugin developers can find usage examples in

--- a/ipod_sync/api_helpers.py
+++ b/ipod_sync/api_helpers.py
@@ -22,7 +22,11 @@ logger = logging.getLogger(__name__)
 def is_ipod_connected(device: str = config.IPOD_DEVICE) -> bool:
     """Return ``True`` if the iPod appears to be connected."""
     if STATUS_FILE.exists():
-        return True
+        try:
+            return STATUS_FILE.read_text().strip().lower() in {"1", "true"}
+        except Exception:  # pragma: no cover - filesystem errors
+            logger.debug("Failed to read status file", exc_info=True)
+            return True
     dev = Path(device)
     if dev.exists():
         return True

--- a/ipod_sync/utils.py
+++ b/ipod_sync/utils.py
@@ -11,7 +11,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from .config import IPOD_MOUNT, IPOD_DEVICE
+from .config import IPOD_MOUNT, IPOD_DEVICE, IPOD_STATUS_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +88,10 @@ def mount_ipod(device: str | None = None) -> None:
     # mount point relies on the ``fstab`` entry to look up the device and
     # works correctly for unprivileged users.
     _run(["mount", str(mount_point)])
+    try:
+        Path(IPOD_STATUS_FILE).write_text("true")
+    except Exception:  # pragma: no cover - filesystem errors
+        logger.debug("Failed to update status file", exc_info=True)
 
 
 def eject_ipod() -> None:
@@ -99,4 +103,8 @@ def eject_ipod() -> None:
     _run(["umount", str(mount_point)])
     logger.info("Ejecting %s", mount_point)
     _run(["eject", str(mount_point)])
+    try:
+        Path(IPOD_STATUS_FILE).unlink(missing_ok=True)
+    except Exception:  # pragma: no cover - filesystem errors
+        logger.debug("Failed to remove status file", exc_info=True)
 

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -78,6 +78,14 @@ def test_is_ipod_connected_status_file(monkeypatch, tmp_path):
     assert api_helpers.is_ipod_connected("/dev/foo")
 
 
+def test_is_ipod_connected_status_true(monkeypatch, tmp_path):
+    status = tmp_path / "status"
+    status.write_text("true")
+    monkeypatch.setattr(api_helpers.config, "IPOD_STATUS_FILE", status)
+    monkeypatch.setattr(api_helpers, "STATUS_FILE", status)
+    assert api_helpers.is_ipod_connected("/dev/foo")
+
+
 def test_is_ipod_connected_mounts(monkeypatch):
     data = "/dev/foo /mnt/ipod vfat rw 0 0\n"
     m = mock.mock_open(read_data=data)


### PR DESCRIPTION
## Summary
- record connection status in `ipod_connected` when mounting/ejecting
- detect connection based on contents of that file
- update unit tests for status file behaviour
- document how the status file drives the dashboard indicator

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d2ecb92883239b465ddde6ff7531