### PR TITLE
Improve FAT partition detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ permission to mount the iPod's block device or the API will fail with a
 the device path in `/etc/fstab`; the default entry looks like:
 
 ```
-/dev/sda1 /opt/ipod-dock/mnt/ipod vfat noauto,user,uid=ipod,gid=ipod 0 0
+/dev/disk/by-label/IPOD /opt/ipod-dock/mnt/ipod vfat noauto,user,uid=ipod,gid=ipod 0 0
+```
+
+Label the iPod's FAT partition once with:
+
+```bash
+sudo fatlabel /dev/sdX2 IPOD
 ```
 
 The listener service attempts to detect the correct FAT partition
@@ -146,7 +152,7 @@ During the early development phase queued files can be synced manually using the
 `sync_from_queue` module:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/sda1
+python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
 ```
 
 Any audio files placed in the `sync_queue/` directory will be imported to the

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -49,7 +49,7 @@ python -m ipod_sync.watcher
 You can also run a manual sync at any time:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/sda1
+python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
 ```
 
 Set environment variables to override defaults:

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ default files are removed from the queue after a successful import.
 Run the script manually with:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/sda1
+python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
 ```
 
 The `--device` argument may be omitted if your iPod is available at the default

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ fi
 sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$PROJECT_DIR"
 
 # Ensure the iPod mount point exists and the user can mount the device
-IPOD_DEVICE="/dev/sda1"
+IPOD_DEVICE="/dev/disk/by-label/IPOD"
 MOUNT_POINT="$TARGET_DIR/mnt/ipod"
 sudo mkdir -p "$MOUNT_POINT"
 sudo chown "$SERVICE_USER":"$SERVICE_USER" "$MOUNT_POINT"

--- a/ipod_sync/config.py
+++ b/ipod_sync/config.py
@@ -16,7 +16,7 @@ IPOD_STATUS_FILE = PROJECT_ROOT / "ipod_connected"
 
 # Default block device representing the iPod. This can be overridden
 # at runtime via command line arguments to the sync script.
-IPOD_DEVICE = "/dev/sda1"
+IPOD_DEVICE = "/dev/disk/by-label/IPOD"
 
 # Whether to keep a copy of files after they are successfully synced.
 KEEP_LOCAL_COPY = False

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -96,6 +96,9 @@ def test_is_ipod_connected_mounts(monkeypatch):
 def test_is_ipod_connected_false(monkeypatch):
     m = mock.mock_open(read_data="/dev/bar /mnt xfs rw 0 0\n")
     monkeypatch.setattr("builtins.open", m)
+    status = Path("/nonexistent/status")
+    monkeypatch.setattr(api_helpers.config, "IPOD_STATUS_FILE", status)
+    monkeypatch.setattr(api_helpers, "STATUS_FILE", status)
     assert not api_helpers.is_ipod_connected("/dev/foo")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,10 +62,16 @@ def test_run_raises_on_error(mock_run):
 
 @mock.patch("ipod_sync.utils.subprocess.run")
 def test_detect_ipod_device_parses_lsblk(mock_run):
-    output = "sda1 vfat\nsda2 ext4\n"
+    output = (
+        '{"blockdevices": ['
+        '{"name": "sda", "children": ['
+        '{"name": "sda1", "fstype": "hfs", "size": "100"},'
+        '{"name": "sda2", "fstype": "vfat", "size": "200"}'
+        ']}]}'
+    )
     mock_run.return_value = subprocess.CompletedProcess([], 0, output, "")
     dev = utils.detect_ipod_device()
-    assert dev == "/dev/sda1"
+    assert dev == "/dev/sda2"
 
 
 @mock.patch("ipod_sync.utils.subprocess.run", side_effect=FileNotFoundError)


### PR DESCRIPTION
## Summary
- detect iPod device by parsing `lsblk --json` and picking the largest vfat partition
- watch block partition events in udev listener and use device node
- default IPOD_DEVICE is `/dev/disk/by-label/IPOD`
- document using a filesystem label and update sync examples
- update installer and tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d6f43aa88323be3f838430243202