### PR TITLE
Improve iPod mount detection

### DIFF
--- a/ipod_sync/udev_listener.py
+++ b/ipod_sync/udev_listener.py
@@ -51,13 +51,16 @@ def listen(
     logger.info("Listening for iPod USB events")
     _set_connected(False)
     for action, dev in monitor:
-        if (
-            dev.get("ID_VENDOR_ID") == vendor
-            and dev.get("ID_MODEL_ID") == product
-        ):
+        if dev.get("ID_VENDOR_ID") == vendor and dev.get("ID_MODEL_ID") == product:
             serial = dev.get("ID_SERIAL_SHORT", "unknown")
             logger.debug("Event %s for %s", action, serial)
-            if action == "add" and dev.device_type == "partition" and dev.get("ID_FS_TYPE") == "vfat":
+            if (
+                action == "add"
+                and dev.device_type == "partition"
+                and (
+                    dev.get("ID_FS_LABEL") == "IPOD" or dev.get("ID_FS_TYPE") == "vfat"
+                )
+            ):
                 logger.info("iPod %s attached", serial)
                 _set_connected(True)
                 try:


### PR DESCRIPTION
## Summary
- wait for /dev/disk/by-label/IPOD before mounting
- verify the iPod's partition label in udev_listener
- update utils tests for wait_for_device

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851de6bc96c8323a4521d9e688c6bbd