### PR TITLE
Fix mounting with correct device argument

### DIFF
--- a/ipod_sync/utils.py
+++ b/ipod_sync/utils.py
@@ -97,18 +97,14 @@ def mount_ipod(device: str | None = None) -> None:
     if device is None:
         device = detect_ipod_device()
 
-    wait_for_device(IPOD_DEVICE)
+    wait_for_device(device)
 
     mount_point: Path = IPOD_MOUNT
     mount_point.mkdir(parents=True, exist_ok=True)
     logger.info("Mounting %s at %s", device, mount_point)
-    # When ``user`` mount permissions are configured in ``/etc/fstab`` a
-    # non-root user may only specify one of the mount point **or** device
-    # name. Passing both causes ``mount`` to abort with "must be superuser"
-    # even if the user is permitted to mount the device. Using only the
-    # mount point relies on the ``fstab`` entry to look up the device and
-    # works correctly for unprivileged users.
-    _run(["mount", str(mount_point)])
+    if not Path(device).exists():
+        raise RuntimeError(f"{device} does not exist")
+    _run(["mount", "-t", "vfat", str(device), str(mount_point)])
     try:
         Path(IPOD_STATUS_FILE).write_text("true")
     except Exception:  # pragma: no cover - filesystem errors

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,13 +15,14 @@ def test_mount_ipod_calls_mount(mock_run, tmp_path):
     mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
     mount_point = tmp_path / "mnt"
     status = tmp_path / "status"
-    device = "/dev/sdb1"
+    device = tmp_path / "sdb1"
+    device.write_text("")
     with mock.patch.object(utils, "IPOD_MOUNT", mount_point), mock.patch.object(
         utils, "IPOD_STATUS_FILE", status
     ), mock.patch.object(utils, "wait_for_device", return_value=True):
-        utils.mount_ipod(device)
+        utils.mount_ipod(str(device))
         mock_run.assert_called_with(
-            ["mount", str(mount_point)],
+            ["mount", "-t", "vfat", str(device), str(mount_point)],
             check=True,
             capture_output=True,
             text=True,
@@ -93,12 +94,15 @@ def test_detect_ipod_device_fallback(mock_run):
     assert dev == "/dev/foo"
 
 
-def test_mount_ipod_auto_detect(monkeypatch):
+def test_mount_ipod_auto_detect(monkeypatch, tmp_path):
     called = {}
+
+    dev = tmp_path / "ipod"
+    dev.write_text("")
 
     def fake_detect():
         called["called"] = True
-        return "/dev/ipod"
+        return str(dev)
 
     monkeypatch.setattr(utils, "detect_ipod_device", fake_detect)
     monkeypatch.setattr(utils, "_run", lambda cmd: None)


### PR DESCRIPTION
## Summary
- ensure `mount_ipod` passes the device path to `mount`
- update unit tests for new call signature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e192360883238484a5601120366d