### PR TITLE
Fix mount timing and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,24 @@ permission to mount the iPod's block device or the API will fail with a
 the device path in `/etc/fstab`; the default entry looks like:
 
 ```
+
 /dev/disk/by-label/IPOD /opt/ipod-dock/mnt/ipod vfat noauto,user,uid=ipod,gid=ipod 0 0
 ```
+
+If you prefer, remove the ``User=`` line from ``*.service`` files so they run
+as ``root`` instead of granting mount permissions. Either approach works; the
+example above keeps the service unprivileged by allowing the ``ipod`` user to
+mount.
+
+Another option is to keep the service user unprivileged but delegate the mount
+command via ``sudo``.  Add a rule to ``/etc/sudoers`` such as:
+
+```
+ipod ALL = (root) NOPASSWD: /bin/mount -t vfat /dev/disk/by-label/IPOD /opt/ipod-dock/mnt/ipod, /bin/umount /opt/ipod-dock/mnt/ipod
+```
+
+With that in place the helpers will call ``sudo mount`` and ``sudo umount`` when
+running under a non-root account.
 
 Label the iPod's FAT partition once with:
 


### PR DESCRIPTION
## Summary
- add `wait_for_label` helper to ensure the `/dev/disk/by-label/IPOD` symlink exists before mounting
- call the new helper in `mount_ipod`
- allow mounting via `sudo` when running unprivileged
- update README with hints about running services as root or using `sudo`
- test waiting for the label and sudo behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851e45b33408323b0a719510e621e72