### PR TITLE
Automate sudoers config in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ mount.
 
 ### Running unprivileged
 
-If you keep ``ipod-listener`` as a non-root service, add the following to
-``/etc/sudoers.d/ipod-dock`` (replace ``ipodsvc`` with your service user):
+If you keep ``ipod-listener`` as a non-root service, ``install.sh`` adds the
+required sudoers rule automatically. The entry looks like this (replace
+``ipodsvc`` with your service user if adding manually):
 
 ```
 ipodsvc ALL=(root) NOPASSWD: \


### PR DESCRIPTION
## Summary
- update README to mention sudoers rule is added automatically
- create `/etc/sudoers.d/ipod-dock` during `install.sh`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531fba232c8323a1e50f907c91eb9a