### PR TITLE
Add udev automount integration

### DIFF
--- a/90-ipod.rules
+++ b/90-ipod.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="129e", ENV{DEVTYPE}=="usb_device", TAG+="systemd", ENV{SYSTEMD_WANTS}="ipod-mount.service"
+

--- a/README.md
+++ b/README.md
@@ -83,11 +83,14 @@ target directory is updated accordingly. Start the services with:
 sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service
 ```
 
-The services run under the dedicated `ipod` account. This user must have
-permission to mount the iPod's block device or the API will fail with a
-"must be superuser" error. `install.sh` creates the mount directory and adds an
-`/etc/fstab` entry so the `ipod` user can mount the device. If needed, adjust
-the device path in `/etc/fstab`; the default entry looks like:
+The services run under the dedicated `ipod` account. `install.sh` now installs
+a `udev` rule and `ipod-mount.service` so the iPod's data partition is
+mounted automatically when connected. The service detects the first FAT
+partition and mounts it at `/opt/ipod-dock/mnt/ipod` using appropriate
+`uid`, `gid` and `umask` options so the `ipod` user has access. If you prefer
+manual control the script also adds an `/etc/fstab` entry so the `ipod` user
+can mount the device without privileges. Adjust the device path in `/etc/fstab`
+if needed; the default entry looks like:
 
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -91,11 +91,14 @@ fi
 
 # Install systemd services if available
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service ipod-mount.service; do
         tmp=$(mktemp)
-        sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
+        sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp" 2>/dev/null || cp "$PROJECT_DIR/$svc" "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
+    sudo install -m 0755 "$PROJECT_DIR/ipod-mount.sh" /usr/local/bin/ipod-mount.sh
+    sudo install -m 0644 "$PROJECT_DIR/90-ipod.rules" /etc/udev/rules.d/90-ipod.rules
+    sudo udevadm control --reload-rules
     sudo systemctl daemon-reload
     sudo systemctl enable ipod-api.service ipod-watcher.service ipod-listener.service
     echo "Services installed. Start them with:\n  sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service"

--- a/ipod-mount.service
+++ b/ipod-mount.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mount iPod Data Partition
+After=systemd-udevd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ipod-mount.sh
+
+

--- a/ipod-mount.sh
+++ b/ipod-mount.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Mount the iPod data partition when triggered by udev.
+
+set -euo pipefail
+
+MOUNT_POINT="/opt/ipod-dock/mnt/ipod"
+MOUNT_USER="ipod"
+
+# Resolve UID/GID for mount options
+UID_NUM=$(id -u "$MOUNT_USER" 2>/dev/null || echo 1000)
+GID_NUM=$(id -g "$MOUNT_USER" 2>/dev/null || echo 1000)
+
+# Detect the first FAT/VFAT partition of any connected drive
+PARTITION=$(lsblk -lno NAME,FSTYPE | awk '$2 ~ /^vfat$/ {print "/dev/"$1; exit}')
+
+if [ -z "$PARTITION" ]; then
+    exit 0
+fi
+
+# Skip if already mounted
+if mountpoint -q "$MOUNT_POINT"; then
+    exit 0
+fi
+
+mkdir -p "$MOUNT_POINT"
+mount -t vfat \
+    -o uid="$UID_NUM",gid="$GID_NUM",umask=000,nosuid,nodev,noatime \
+    "$PARTITION" "$MOUNT_POINT"
+

--- a/ipod_sync/udev_listener.py
+++ b/ipod_sync/udev_listener.py
@@ -34,7 +34,7 @@ def _set_connected(connected: bool) -> None:
 def listen(
     device: str | None = None,
     vendor: str = "05ac",
-    product: str = "1209",
+    product: str = "129e",
     monitor: Iterable[Tuple[str, pyudev.Device]] | None = None,
 ) -> None:
     """Listen for matching USB device events and sync on attach.
@@ -81,7 +81,7 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to iPod block device (auto-detect if omitted)",
     )
     parser.add_argument("--vendor", default="05ac", help="USB vendor ID")
-    parser.add_argument("--product", default="1209", help="USB product ID")
+    parser.add_argument("--product", default="129e", help="USB product ID")
     args = parser.parse_args(argv)
 
     setup_logging()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,8 @@ def test_eject_ipod_calls_umount_and_eject(mock_run, tmp_path):
     status.write_text("true")
     with mock.patch.object(utils, "IPOD_MOUNT", mount_point), \
          mock.patch.object(utils, "IPOD_STATUS_FILE", status), \
-         mock.patch("os.geteuid", return_value=1000):
+         mock.patch("os.geteuid", return_value=1000), \
+         mock.patch("os.path.ismount", return_value=True):
         utils.eject_ipod()
         mock_run.assert_has_calls(
             [
@@ -119,6 +120,19 @@ def test_eject_ipod_calls_umount_and_eject(mock_run, tmp_path):
             ]
         )
         assert not status.exists()
+
+
+@mock.patch("ipod_sync.utils.subprocess.run")
+def test_eject_ipod_skips_when_not_mounted(mock_run, tmp_path):
+    mount_point = tmp_path / "mnt"
+    status = tmp_path / "status"
+    status.write_text("true")
+    with mock.patch.object(utils, "IPOD_MOUNT", mount_point), \
+         mock.patch.object(utils, "IPOD_STATUS_FILE", status), \
+         mock.patch("os.path.ismount", return_value=False):
+        utils.eject_ipod()
+    mock_run.assert_not_called()
+    assert not status.exists()
 
 
 @mock.patch("ipod_sync.utils.subprocess.run")

--- a/update.sh
+++ b/update.sh
@@ -37,11 +37,14 @@ sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$TARGET_DIR"
 
 # Refresh systemd units and restart services
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service ipod-mount.service; do
         tmp=$(mktemp)
-        sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp"
+        sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp" 2>/dev/null || cp "$PROJECT_DIR/$svc" "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
+    sudo install -m 0755 "$PROJECT_DIR/ipod-mount.sh" /usr/local/bin/ipod-mount.sh
+    sudo install -m 0644 "$PROJECT_DIR/90-ipod.rules" /etc/udev/rules.d/90-ipod.rules
+    sudo udevadm control --reload-rules
     sudo systemctl daemon-reload
     sudo systemctl restart ipod-api.service ipod-watcher.service ipod-listener.service
 fi


### PR DESCRIPTION
## Summary
- refine udev rule and listener defaults for iPod USB product 129e
- improve ipod-mount.sh to resolve UID/GID and handle existing mounts
- add udev dependency to ipod-mount.service
- document automatic mount behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68532e03d1fc83239be83f49664e8c67