### PR TITLE
Add audible-cli install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,10 @@ sudo apt-get update
 sudo apt-get install libgpod-common ffmpeg
 ```
 
-Install `audible-cli` to enable the Audible import feature and run the
-quickstart to authenticate:
+`install.sh` and `update.sh` install `audible-cli` automatically. Run the
+quickstart afterwards to authenticate:
 
 ```bash
-pip install audible-cli
 audible quickstart
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,7 @@ source "$PROJECT_DIR/.venv/bin/activate"
 # Install Python packages
 pip install -U pip
 pip install -r "$PROJECT_DIR/requirements.txt"
+pip install audible-cli
 
 # Ensure dedicated service user exists
 # Create or update the service user

--- a/update.sh
+++ b/update.sh
@@ -26,6 +26,7 @@ fi
 
 sudo -u "$SERVICE_USER" "$TARGET_DIR/.venv/bin/pip" install -U pip
 sudo -u "$SERVICE_USER" "$TARGET_DIR/.venv/bin/pip" install -r "$TARGET_DIR/requirements.txt"
+sudo -u "$SERVICE_USER" "$TARGET_DIR/.venv/bin/pip" install audible-cli
 
 # Ensure the service user exists
 if id "$SERVICE_USER" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- install Audible CLI automatically in install and update scripts
- adjust readme for new Audible CLI instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685469c628148323a85460a7f66063c1