### PR TITLE
Add YouTube download endpoints

### DIFF
--- a/docs/plugin_api.md
+++ b/docs/plugin_api.md
@@ -92,6 +92,29 @@ curl -X POST -H "X-API-Key: <key>" -H "Content-Type: application/json" \
 
 The response lists the filenames that were downloaded.
 
+### `POST /youtube`
+Download a YouTube video and queue the audio. Provide a JSON body containing
+`url` and an optional `category` field. The `category` may be `music`,
+`audiobook` or `podcast`.
+
+```bash
+curl -X POST -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+     -d '{"url": "https://youtu.be/dQw4w9WgXcQ", "category": "music"}' \
+     http://<pi>:8000/youtube
+```
+
+### `POST /youtube/{category}`
+Download a YouTube video into the specified category. The request body must
+provide `url`.
+
+```bash
+curl -X POST -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+     -d '{"url": "https://youtu.be/dQw4w9WgXcQ"}' \
+     http://<pi>:8000/youtube/podcast
+```
+
+The response contains the queued filename and category.
+
 ### `GET /stats`
 Return basic dashboard information such as track count, queue size and storage usage.
 

--- a/ipod_sync/youtube_downloader.py
+++ b/ipod_sync/youtube_downloader.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Helpers for downloading audio from YouTube URLs using ``yt-dlp``."""
+
+import logging
+from pathlib import Path
+
+from yt_dlp import YoutubeDL
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+
+def download_audio(
+    url: str, category: str = "music", queue_dir: Path | None = None
+) -> Path:
+    """Download *url* and return the queued file path.
+
+    Parameters
+    ----------
+    url:
+        YouTube URL to download.
+    category:
+        One of ``"music"``, ``"audiobook"`` or ``"podcast"`` determining the
+        subdirectory under the queue where the file will be placed.
+    queue_dir:
+        Base queue directory. Defaults to ``config.SYNC_QUEUE_DIR``.
+    """
+    queue = Path(queue_dir) if queue_dir else Path(config.SYNC_QUEUE_DIR)
+    if category:
+        queue = queue / category
+    queue.mkdir(parents=True, exist_ok=True)
+
+    outtmpl = str(queue / "%(title)s.%(ext)s")
+    opts = {
+        "format": "bestaudio/best",
+        "outtmpl": outtmpl,
+        "quiet": True,
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "mp3",
+                "preferredquality": "192",
+            }
+        ],
+    }
+
+    logger.info("Downloading %s to %s", url, queue)
+    with YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        filename = Path(ydl.prepare_filename(info)).with_suffix(".mp3")
+    logger.info("Downloaded %s", filename.name)
+    return filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ iniconfig==2.1.0
 packaging==25.0
 pluggy==1.6.0
 pygments==2.19.1
+yt-dlp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -196,3 +196,26 @@ def test_control_invalid(mock_ctl):
     response = client.post("/control/boom")
     assert response.status_code == 400
     mock_ctl.play_pause.assert_not_called()
+
+
+@mock.patch.object(app_module.youtube_downloader, "download_audio")
+def test_youtube_endpoint(mock_dl):
+    mock_dl.return_value = Path("sync_queue/music/song.mp3")
+    resp = client.post("/youtube", json={"url": "http://yt"})
+    assert resp.status_code == 200
+    assert resp.json() == {"queued": "song.mp3", "category": "music"}
+    mock_dl.assert_called_once_with("http://yt", "music")
+
+
+@mock.patch.object(app_module.youtube_downloader, "download_audio")
+def test_youtube_category_endpoint(mock_dl):
+    mock_dl.return_value = Path("sync_queue/podcast/ep.mp3")
+    resp = client.post("/youtube/podcast", json={"url": "http://yt"})
+    assert resp.status_code == 200
+    assert resp.json() == {"queued": "ep.mp3", "category": "podcast"}
+    mock_dl.assert_called_once_with("http://yt", "podcast")
+
+
+def test_youtube_missing_url():
+    resp = client.post("/youtube", json={})
+    assert resp.status_code == 400

--- a/tests/test_youtube_downloader.py
+++ b/tests/test_youtube_downloader.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from unittest import mock
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ipod_sync import youtube_downloader
+
+
+def test_download_audio_creates_path(tmp_path):
+    mock_dl = mock.MagicMock()
+    mock_dl.__enter__.return_value = mock_dl
+    mock_dl.extract_info.return_value = {"id": "1", "ext": "webm"}
+    mock_dl.prepare_filename.return_value = str(tmp_path / "music" / "foo.webm")
+    with mock.patch("ipod_sync.youtube_downloader.YoutubeDL", return_value=mock_dl):
+        path = youtube_downloader.download_audio("http://yt", "music", tmp_path)
+    assert path == tmp_path / "music" / "foo.mp3"
+    mock_dl.extract_info.assert_called_once_with("http://yt", download=True)


### PR DESCRIPTION
## Summary
- download YT links with new helper `youtube_downloader.py`
- expose `/youtube` and `/youtube/{category}` endpoints
- document the API changes
- include yt-dlp in requirements
- tests for the new helper and endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546dba92fc8323bc611e186181deb7