### PR TITLE
Update mount documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,28 +102,28 @@ mount.
 ### Running unprivileged
 
 If you keep ``ipod-listener`` as a non-root service, ``install.sh`` adds the
-required sudoers rule automatically. The entry looks like this (replace
-``ipodsvc`` with your service user if adding manually):
+required sudoers rule automatically. The entry allows `ipod-mount.sh` to mount
+the iPod when triggered by udev. Replace ``ipodsvc`` with your service user if
+adding manually:
 
 ```
 ipodsvc ALL=(root) NOPASSWD: \
-    /bin/mount -t vfat /dev/disk/by-label/IPOD /opt/ipod-dock/mnt/ipod, \
+    /usr/local/bin/ipod-mount.sh, \
     /bin/umount /opt/ipod-dock/mnt/ipod
 ```
 
 The listener auto-detects when it is not running as uid 0 and silently prefixes
 those commands with ``sudo --non-interactive --``.
 
-Label the iPod's FAT partition once with:
+The mount helper auto-detects the iPod's FAT partition so labeling is
+optional. If you want to set a label for clarity:
 
 ```bash
 sudo fatlabel /dev/sdX2 IPOD
 ```
 
-The listener service attempts to detect the correct FAT partition
-automatically when the iPod is connected.  You can override the detected
-device by passing ``--device`` to the scripts or updating
-``config.IPOD_DEVICE``.
+You can override the detected device by passing ``--device`` to the scripts
+or updating ``config.IPOD_DEVICE``.
 
 To manually mount the device you can run:
 
@@ -184,8 +184,9 @@ During the early development phase queued files can be synced manually using the
 `sync_from_queue` module:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
+python -m ipod_sync.sync_from_queue
 ```
+Add ``--device /dev/sdX2`` if you need to override the detected partition.
 
 Any audio files placed in the `sync_queue/` directory will be imported to the
 iPod and removed from the queue. Files using formats the iPod cannot play are

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -34,6 +34,10 @@ script also installs other tools like `automake`.
 
 ## Running the services
 
+A udev rule installs `ipod-mount.service` which mounts the iPod automatically
+when it is connected. The helper script detects the first FAT partition and
+mounts it at `/opt/ipod-dock/mnt/ipod`.
+
 Start the API server:
 
 ```bash
@@ -49,8 +53,9 @@ python -m ipod_sync.watcher
 You can also run a manual sync at any time:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
+python -m ipod_sync.sync_from_queue
 ```
+Add ``--device /dev/sdX2`` if you need to override the detected partition.
 
 Set environment variables to override defaults:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,9 @@ working on the project.
 ## Mount helpers
 
 `ipod_sync.utils` provides small wrappers for mounting and ejecting the iPod.
-They call the system `mount`, `umount` and `eject` commands using Python's
+A udev rule triggers `ipod-mount.service` which runs `ipod-mount.sh` to mount
+the first FAT partition automatically when the iPod is connected. The helpers
+call the system `mount`, `umount` and `eject` commands using Python's
 `subprocess` module and log any output for debugging. The helpers are:
 
 - `mount_ipod(device: str)` – mounts the given block device to the configured
@@ -61,11 +63,9 @@ default files are removed from the queue after a successful import.
 Run the script manually with:
 
 ```bash
-python -m ipod_sync.sync_from_queue --device /dev/disk/by-label/IPOD
+python -m ipod_sync.sync_from_queue
 ```
-
-The `--device` argument may be omitted if your iPod is available at the default
-path configured in `config.IPOD_DEVICE`.
+Add ``--device /dev/sdX2`` to override the detected partition if needed.
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- document automatic mount service
- note auto-detection of the iPod FAT partition
- update sync examples to omit the --device option

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858188a8b988323b0a63814a872efe2