### PR TITLE
Improve npm install handling in UI test

### DIFF
--- a/tests/test_upload_ui.py
+++ b/tests/test_upload_ui.py
@@ -1,8 +1,17 @@
 import subprocess
+from pathlib import Path
 
 
 def test_upload_ui_event_listener():
-    # ensure jsdom installed
-    subprocess.run(["npm", "install"], check=True)
-    result = subprocess.run(["node", "tests/ui_event_listener.js"], capture_output=True, text=True, check=True)
+    """Run the UI event listener with jsdom available."""
+    # Only install dependencies if they are missing. Using ``npm ci`` ensures
+    # a clean, reproducible install when ``node_modules`` is not present.
+    if not Path("node_modules").exists():
+        subprocess.run(["npm", "ci"], check=True)
+
+    result = subprocess.run([
+        "node",
+        "tests/ui_event_listener.js",
+    ], capture_output=True, text=True, check=True)
+
     assert result.stdout.strip() == "ok"


### PR DESCRIPTION
## Summary
- avoid repeated dependency installs for UI tests
- use `npm ci` when `node_modules` is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6867f8cf29a8832395557dda5d40c699