### PR TITLE
Update httpx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 watchdog
-httpx
+httpx<0.24
 python-multipart
 feedparser
 pytest
@@ -14,7 +14,7 @@ sniffio==1.3.1
 click==8.2.1
 h11==0.16.0
 certifi==2025.6.15
-httpcore==1.0.9
+httpcore<0.17
 sgmllib3k==1.0.0
 iniconfig==2.1.0
 packaging==25.0


### PR DESCRIPTION
## Summary
- pin `httpx` to `<0.24`
- constrain `httpcore` for compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TypeError, AttributeError, SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_6867f8b4d1208323b428112fb4c42d87