### PR TITLE
Fix libgpod build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ audible quickstart
 Sadly debain distro bookworm does not provide the `python3-gpod` package.
 `install.sh` will build the libgpod bindings from the
 [`gerion0/libgpod`](https://github.com/gerion0/libgpod) fork, which uses Meson
-and includes Python 3 support. This requires the SQLite development headers and
-libxml2 development files which can be installed with:
+and includes Python 3 support. This requires the SQLite development headers,
+libxml2 development files, `python-gi-dev` and the `python3-mutagen` module.
+Install the prerequisites with:
 
 ```bash
-sudo apt-get install libsqlite3-dev libxml2-dev
+sudo apt-get install libsqlite3-dev libxml2-dev python-gi-dev python3-mutagen
 ```
 
 The script also installs other build tools such as `automake`.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -29,8 +29,9 @@ sudo apt-get install libgpod-common ffmpeg
 If the `python3-gpod` package is missing, run `../install.sh` to build the
 libgpod bindings from the [`gerion0/libgpod`](https://github.com/gerion0/libgpod)
 fork with Python 3 support. The build uses Meson and requires the SQLite
-development headers (`libsqlite3-dev`) and the libxml2 development package
-(`libxml2-dev`).
+development headers (`libsqlite3-dev`), the libxml2 development package
+(`libxml2-dev`), the PyGObject development files (`python-gi-dev`) and the
+`python3-mutagen` module.
 
 ## Running the services
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,8 @@ sudo apt-get install libgpod-common
 If `python3-gpod` isn't packaged on your system, the `install.sh` script will
 download and build the bindings from the
 [`gerion0/libgpod`](https://github.com/gerion0/libgpod) fork, which uses the
-Meson build system.
+Meson build system. Ensure `python-gi-dev` and `python3-mutagen` are installed
+before running the build.
 
 The module exposes three simple helpers:
 

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,8 @@ build_libgpod() {
     sudo apt-get install -y build-essential git meson ninja-build \
         swig libtool intltool gtk-doc-tools \
         libglib2.0-dev libimobiledevice-dev libplist-dev libxml2-dev \
-        libgdk-pixbuf2.0-dev python3-dev libsqlite3-dev
+        libgdk-pixbuf2.0-dev python3-dev libsqlite3-dev \
+        python-gi-dev python3-mutagen
 
     workdir=$(mktemp -d)
     git clone --depth 1 https://github.com/gerion0/libgpod.git "$workdir/libgpod"


### PR DESCRIPTION
## Summary
- add python-gi-dev and python3-mutagen when building libgpod
- mention new dependencies in docs

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q` *(fails: AttributeError: module 'httpx._client' has no attribute 'USE_CLIENT_DEFAULT')*

------
https://chatgpt.com/codex/tasks/task_e_68681412d6e083238ef8976ac4985fe1