### PR TITLE
Update libgpod source

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ audible quickstart
 
 Sadly debain distro bookworm does not provide the `python3-gpod` package.
 `install.sh` will build the libgpod bindings from the
-[`gerion0/libgpod`](https://github.com/gerion0/libgpod) fork, which uses Meson
+[`Brownster/libgpod`](https://github.com/Brownster/libgpod) fork, which uses Meson
 and includes Python 3 support. This requires the SQLite development headers,
 libxml2 development files, `python-gi-dev` and the `python3-mutagen` module.
 Install the prerequisites with:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -27,7 +27,7 @@ sudo apt-get install libgpod-common ffmpeg
 ```
 
 If the `python3-gpod` package is missing, run `../install.sh` to build the
-libgpod bindings from the [`gerion0/libgpod`](https://github.com/gerion0/libgpod)
+libgpod bindings from the [`Brownster/libgpod`](https://github.com/Brownster/libgpod)
 fork with Python 3 support. The build uses Meson and requires the SQLite
 development headers (`libsqlite3-dev`), the libxml2 development package
 (`libxml2-dev`), the PyGObject development files (`python-gi-dev`) and the

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,7 +41,7 @@ sudo apt-get install libgpod-common
 
 If `python3-gpod` isn't packaged on your system, the `install.sh` script will
 download and build the bindings from the
-[`gerion0/libgpod`](https://github.com/gerion0/libgpod) fork, which uses the
+[`Brownster/libgpod`](https://github.com/Brownster/libgpod) fork, which uses the
 Meson build system. Ensure `python-gi-dev` and `python3-mutagen` are installed
 before running the build.
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ build_libgpod() {
         python-gi-dev python3-mutagen
 
     workdir=$(mktemp -d)
-    git clone --depth 1 https://github.com/gerion0/libgpod.git "$workdir/libgpod"
+    git clone --depth 1 https://github.com/Brownster/libgpod.git "$workdir/libgpod"
     pushd "$workdir/libgpod" >/dev/null
     meson setup build --prefix=/usr
     ninja -C build


### PR DESCRIPTION
## Summary
- use Brownster fork for libgpod in install script
- update documentation links for the libgpod fork

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AttributeError: module 'httpx._client' has no attribute 'USE_CLIENT_DEFAULT')*

------
https://chatgpt.com/codex/tasks/task_e_686816b4919883239f0c4bc7e4bc65ef