### PR TITLE
Fix tests with updated httpx and CLI options

### DIFF
--- a/ipod_sync/libpod_wrapper.py
+++ b/ipod_sync/libpod_wrapper.py
@@ -25,7 +25,8 @@ try:  # pragma: no cover - the import will be mocked in tests
     GpodException = gpod.GpodException
 except (ImportError, AttributeError):  # pragma: no cover - handled at runtime
     gpod = None
-    GpodException = None  # type: ignore
+    class GpodException(Exception):
+        pass
     logger.debug("python-gpod bindings not available")
 
 

--- a/ipod_sync/sync_from_queue.py
+++ b/ipod_sync/sync_from_queue.py
@@ -14,6 +14,7 @@ from . import config
 from .logging_setup import setup_logging
 from .libpod_wrapper import add_track, LibpodError
 from . import converter
+from .utils import mount_ipod, eject_ipod
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ def sync_queue(mount_point: str) -> None:
     if not files:
         logger.info("No files to sync in %s", queue)
         return
+
+    mount_ipod(mount_point)
 
     logger.info("Starting sync to %s", mount_point)
     for file in files:
@@ -54,14 +57,17 @@ def sync_queue(mount_point: str) -> None:
         except LibpodError as exc:
             logger.error("Failed to sync %s: %s", file, exc)
         except Exception as exc:  # pragma: no cover - unexpected failures
-            logger.error("An unexpected error occurred while syncing %s: %s", file, exc)
+            logger.error("Failed to sync %s: %s", file, exc)
     logger.info("Sync finished")
+    eject_ipod()
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Sync queued files to an iPod")
     parser.add_argument(
-        "mount_point",
+        "--device",
+        dest="mount_point",
+        default=str(config.IPOD_MOUNT),
         help="Path to iPod mount point",
     )
     args = parser.parse_args(argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 watchdog
-httpx<0.24
+httpx>=0.27,<0.29
 python-multipart
 feedparser
 pytest
@@ -14,7 +14,7 @@ sniffio==1.3.1
 click==8.2.1
 h11==0.16.0
 certifi==2025.6.15
-httpcore<0.17
+httpcore>=1.0,<2.0
 sgmllib3k==1.0.0
 iniconfig==2.1.0
 packaging==25.0


### PR DESCRIPTION
## Summary
- bump httpx/httpcore versions for compatibility with latest starlette
- import gpod fallback exception so unit tests pass
- ensure sync_from_queue mounts/ejects correctly and add --device CLI option
- adjust udev listener to accept a device argument and simplify handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868179c4b7483238c02df113a8ac520