### PR TITLE
Fix install docs by removing obsolete mount service

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,13 @@ target directory is updated accordingly. Start the services with:
 sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service
 ```
 
-The services run under the dedicated `ipod` account. `install.sh` now installs
-a `udev` rule and `ipod-mount.service` so the iPod's data partition is
-mounted automatically when connected. The service detects the first FAT
-partition and mounts it at `/opt/ipod-dock/mnt/ipod` using appropriate
-`uid`, `gid` and `umask` options so the `ipod` user has access. Mounting is
-performed via a sudoers rule so the service can invoke `mount` without a
-password. If you prefer manual control you may add an `/etc/fstab` entry
-yourself so the `ipod` user can mount the device without sudo.
+The services run under the dedicated `ipod` account. `ipod-listener.service`
+mounts the iPod automatically when it is connected. The listener detects the
+first FAT partition and mounts it at `/opt/ipod-dock/mnt/ipod` using
+appropriate `uid`, `gid` and `umask` options so the `ipod` user has access.
+Mounting is performed via a sudoers rule so the service can invoke `mount`
+without a password. If you prefer manual control you may add an `/etc/fstab`
+entry yourself so the `ipod` user can mount the device without sudo.
 
 If you prefer, remove the ``User=`` line from ``*.service`` files so they run
 as ``root`` instead of granting mount permissions. Either approach works; the
@@ -102,13 +101,13 @@ mount.
 ### Running unprivileged
 
 If you keep ``ipod-listener`` as a non-root service, ``install.sh`` adds the
-required sudoers rule automatically. The entry allows `ipod-mount.sh` to mount
-the iPod when triggered by udev. Replace ``ipodsvc`` with your service user if
-adding manually:
+required sudoers rule automatically. The entry allows the service to run
+``mount`` and ``umount`` for the iPod without a password. Replace ``ipodsvc``
+with your service user if adding manually:
 
 ```
 ipodsvc ALL=(root) NOPASSWD: \
-    /usr/local/bin/ipod-mount.sh, \
+    /bin/mount -t vfat * /opt/ipod-dock/mnt/ipod, \
     /bin/umount /opt/ipod-dock/mnt/ipod
 ```
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -35,9 +35,9 @@ development headers (`libsqlite3-dev`), the libxml2 development package
 
 ## Running the services
 
-A udev rule installs `ipod-mount.service` which mounts the iPod automatically
-when it is connected. The helper script detects the first FAT partition and
-mounts it at `/opt/ipod-dock/mnt/ipod`.
+`ipod-listener.service` monitors USB events and mounts the iPod automatically
+when it is connected. The listener detects the first FAT partition and mounts it
+at `/opt/ipod-dock/mnt/ipod`.
 
 Start the API server:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,10 +6,10 @@ working on the project.
 ## Mount helpers
 
 `ipod_sync.utils` provides small wrappers for mounting and ejecting the iPod.
-A udev rule triggers `ipod-mount.service` which runs `ipod-mount.sh` to mount
-the first FAT partition automatically when the iPod is connected. The helpers
-call the system `mount`, `umount` and `eject` commands using Python's
-`subprocess` module and log any output for debugging. The helpers are:
+`ipod-listener.service` handles USB events and automatically mounts the first
+FAT partition when the iPod is connected. The helpers call the system `mount`,
+`umount` and `eject` commands using Python's `subprocess` module and log any
+output for debugging. The helpers are:
 
 - `mount_ipod(device: str)` – mounts the given block device to the configured
   `IPOD_MOUNT` directory.

--- a/install.sh
+++ b/install.sh
@@ -83,14 +83,11 @@ fi
 
 # Install systemd services if available
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service ipod-listener.service ipod-mount.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
         tmp=$(mktemp)
         sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp" 2>/dev/null || cp "$PROJECT_DIR/$svc" "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
-    sudo install -m 0755 "$PROJECT_DIR/ipod-mount.sh" /usr/local/bin/ipod-mount.sh
-    sudo install -m 0644 "$PROJECT_DIR/90-ipod.rules" /etc/udev/rules.d/90-ipod.rules
-    sudo udevadm control --reload-rules
     sudo systemctl daemon-reload
     sudo systemctl enable ipod-api.service ipod-watcher.service ipod-listener.service
     echo "Services installed. Start them with:\n  sudo systemctl start ipod-api.service ipod-watcher.service ipod-listener.service"

--- a/update.sh
+++ b/update.sh
@@ -38,14 +38,11 @@ sudo chown -R "$SERVICE_USER":"$SERVICE_USER" "$TARGET_DIR"
 
 # Refresh systemd units and restart services
 if command -v systemctl >/dev/null; then
-    for svc in ipod-api.service ipod-watcher.service ipod-listener.service ipod-mount.service; do
+    for svc in ipod-api.service ipod-watcher.service ipod-listener.service; do
         tmp=$(mktemp)
         sed "s|User=.*|User=$SERVICE_USER|" "$PROJECT_DIR/$svc" > "$tmp" 2>/dev/null || cp "$PROJECT_DIR/$svc" "$tmp"
         sudo mv "$tmp" "/etc/systemd/system/$svc"
     done
-    sudo install -m 0755 "$PROJECT_DIR/ipod-mount.sh" /usr/local/bin/ipod-mount.sh
-    sudo install -m 0644 "$PROJECT_DIR/90-ipod.rules" /etc/udev/rules.d/90-ipod.rules
-    sudo udevadm control --reload-rules
     sudo systemctl daemon-reload
     sudo systemctl restart ipod-api.service ipod-watcher.service ipod-listener.service
 fi


### PR DESCRIPTION
## Summary
- remove ipod-mount.service from install/update scripts
- update README and docs to describe new automount approach using ipod-listener

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686820bf59cc8323b8222ba97991c7cc