### PR TITLE
Fix libpod wrapper compatibility and device eject logic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,6 +131,18 @@ def test_eject_ipod_calls_umount_and_eject(mock_run, tmp_path):
             [
                 mock.call(
                     [
+                        "findmnt",
+                        "-n",
+                        "-o",
+                        "SOURCE",
+                        str(mount_point),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ),
+                mock.call(
+                    [
                         "sudo",
                         "--non-interactive",
                         "--",


### PR DESCRIPTION
## Summary
- improve libpod_wrapper compatibility with python-gpod and tests
- use system `mount` for mounting iPods
- eject underlying block device instead of the mount point
- update tests for new eject behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685983ba68832392623f8348c371a9