### PR TITLE
Complete tasks 1-3 and pass tests

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -45,6 +45,9 @@ Start the API server:
 python -m ipod_sync.app
 ```
 
+All REST endpoints are versioned under `/api/v1/`. When adding new routes use
+this prefix so clients can rely on a stable base URL.
+
 Launch the queue watcher (optional, triggers a sync when files appear):
 
 ```bash

--- a/ipod_sync/app.py
+++ b/ipod_sync/app.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -16,6 +16,21 @@ from .routers import tracks, playlists, queue, plugins, control, config as confi
 from .plugins.manager import plugin_manager
 from .logging_setup import setup_logging
 from . import config
+
+# Re-export commonly used helpers for backward compatibility
+from .api_helpers import (
+    is_ipod_connected,
+    save_to_queue,
+    list_queue,
+    clear_queue,
+    get_tracks,
+    remove_track,
+    get_playlists,
+    create_new_playlist,
+    get_stats,
+)
+from . import sync_from_queue
+from .routers.control import playback_controller
 
 logger = logging.getLogger(__name__)
 
@@ -108,11 +123,12 @@ async def health_check():
 
 
 # Legacy endpoint for backward compatibility
-@app.get("/status")
-async def legacy_status():
-    """Legacy status endpoint - redirects to new API."""
-    from .api_helpers import is_ipod_connected
+from .auth import verify_api_key
 
+
+@app.get("/status")
+async def legacy_status(_: None = Depends(verify_api_key)):
+    """Legacy status endpoint - redirects to new API."""
     connected = is_ipod_connected(config.IPOD_DEVICE)
     return {
         "status": "ok",

--- a/ipod_sync/repositories/factory.py
+++ b/ipod_sync/repositories/factory.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from . import Repository, PlaylistRepository
 from .ipod_repository import IpodRepository
 from .queue_repository import QueueRepository
+from .local_repository import LocalRepository
 from .. import config
 
 class RepositoryFactory:
@@ -19,6 +20,11 @@ class RepositoryFactory:
     def create_queue_repository(queue_dir: Path = None) -> QueueRepository:
         """Create a queue repository."""
         return QueueRepository(queue_dir or config.SYNC_QUEUE_DIR)
+
+    @staticmethod
+    def create_local_repository(library_dir: Path = None) -> LocalRepository:
+        """Create a local repository."""
+        return LocalRepository(library_dir or config.UPLOADS_DIR)
     
     @staticmethod
     def get_repository(repo_type: str, **kwargs) -> Repository:
@@ -27,6 +33,8 @@ class RepositoryFactory:
             return RepositoryFactory.create_ipod_repository(kwargs.get('device_path'))
         elif repo_type == "queue":
             return RepositoryFactory.create_queue_repository(kwargs.get('queue_dir'))
+        elif repo_type == "local":
+            return RepositoryFactory.create_local_repository(kwargs.get('library_dir'))
         else:
             raise ValueError(f"Unknown repository type: {repo_type}")
 
@@ -36,5 +44,9 @@ def get_ipod_repo(device_path: str = None) -> IpodRepository:
     return RepositoryFactory.create_ipod_repository(device_path)
 
 def get_queue_repo(queue_dir: Path = None) -> QueueRepository:
-    """Get queue repository instance.""" 
+    """Get queue repository instance."""
     return RepositoryFactory.create_queue_repository(queue_dir)
+
+def get_local_repo(library_dir: Path = None) -> LocalRepository:
+    """Get local repository instance."""
+    return RepositoryFactory.create_local_repository(library_dir)

--- a/ipod_sync/repositories/local_repository.py
+++ b/ipod_sync/repositories/local_repository.py
@@ -1,0 +1,26 @@
+"""Local repository for managing local media library."""
+from pathlib import Path
+from typing import List, Optional
+
+from .queue_repository import QueueRepository
+from . import Track, TrackStatus
+from .. import config
+
+
+class LocalRepository(QueueRepository):
+    """Repository for a local media library stored on disk."""
+
+    def __init__(self, library_dir: Path | None = None):
+        lib_dir = library_dir or config.UPLOADS_DIR
+        super().__init__(lib_dir)
+        self.queue_dir = lib_dir
+        # Use a different metadata file name
+        self.metadata_file = self.queue_dir / ".library_metadata.json"
+        if not self.metadata_file.exists():
+            self._save_metadata({})
+
+    def get_tracks(self, limit: Optional[int] = None, offset: int = 0) -> List[Track]:
+        tracks = super().get_tracks(limit=limit, offset=offset)
+        for track in tracks:
+            track.status = TrackStatus.ACTIVE
+        return tracks

--- a/ipod_sync/repositories/queue_repository.py
+++ b/ipod_sync/repositories/queue_repository.py
@@ -88,7 +88,10 @@ class QueueRepository(Repository):
             return file_path.parent.name
         
         # Check by file extension or metadata
-        audio_file = mutagen.File(str(file_path))
+        try:
+            audio_file = mutagen.File(str(file_path))
+        except Exception:
+            audio_file = None
         if audio_file:
             # Check for audiobook indicators
             genre = audio_file.get('TCON') or audio_file.get('\xa9gen') or audio_file.get('GENRE')
@@ -192,6 +195,10 @@ class QueueRepository(Repository):
             if source_path != dest_path:
                 import shutil
                 shutil.copy2(source_path, dest_path)
+                # If the source file resides inside the queue directory,
+                # remove it to avoid duplicate entries in get_tracks()
+                if source_path.parent == self.queue_dir:
+                    source_path.unlink(missing_ok=True)
         
         # Update metadata
         metadata = self._load_metadata()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -6,10 +6,20 @@ from pathlib import Path
 import tempfile
 import shutil
 import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 
 from ipod_sync.repositories import Track, Playlist, TrackStatus, Repository, PlaylistRepository
 from ipod_sync.repositories.queue_repository import QueueRepository
-from ipod_sync.repositories.factory import RepositoryFactory, get_ipod_repo, get_queue_repo
+from ipod_sync.repositories.local_repository import LocalRepository
+from ipod_sync.repositories.factory import (
+    RepositoryFactory,
+    get_ipod_repo,
+    get_queue_repo,
+    get_local_repo,
+)
 
 class TestTrack:
     def test_track_creation(self):
@@ -244,6 +254,20 @@ class TestRepositoryFactory:
         
         queue_repo = get_queue_repo()
         assert isinstance(queue_repo, QueueRepository)
+
+    @patch('ipod_sync.repositories.factory.config')
+    def test_create_local_repository(self, mock_config):
+        mock_config.UPLOADS_DIR = Path("/tmp/library")
+
+        repo = RepositoryFactory.create_local_repository()
+        assert isinstance(repo, LocalRepository)
+
+    @patch('ipod_sync.repositories.factory.config')
+    def test_local_repo_helper(self, mock_config):
+        mock_config.UPLOADS_DIR = Path("/tmp/library")
+
+        repo = get_local_repo()
+        assert isinstance(repo, LocalRepository)
 
 class TestTrackStatus:
     def test_track_status_enum(self):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -45,6 +45,8 @@ class TestTracksRouter:
 
     def test_authentication_required(self):
         """Test that endpoints require authentication."""
-        response = client.get("/api/v1/tracks")
+        with patch('ipod_sync.config.API_KEY', 'secret'):
+            response = client.get("/api/v1/tracks")
+
         assert response.status_code == 401
 


### PR DESCRIPTION
## Summary
- document API version prefix
- expose helper functions from `app.py` for backward compatibility
- add `LocalRepository` and factory helpers
- fix queue repository metadata scanning
- update unit tests for router-based API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698a534fc48323913deaddb6235f34