### PR TITLE
Implement configuration validation system

### DIFF
--- a/config/config.production.json
+++ b/config/config.production.json
@@ -1,0 +1,13 @@
+{
+  "log_level": "WARNING",
+  "server": {
+    "host": "0.0.0.0",
+    "port": 80,
+    "cors_origins": ["https://yourdomain.com"]
+  },
+  "audio": {
+    "conversion_bitrate": 256,
+    "normalize_audio": true
+  },
+  "keep_local_copy": true
+}


### PR DESCRIPTION
## Summary
- add validation methods to configuration dataclasses
- expand environment override support
- add configuration reload and environment info endpoints
- include production profile example

## Testing
- `pip install -r requirements.txt`
- `pip install mutagen`
- `PYTHONPATH=. pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686991f8fff88323834eae409f3d2577