### PR TITLE
Update docs for tasks 1-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ See [research.md](research.md) for notes on the hardware setup and [wiring instr
   track skipping.
 - **Rotating log files** stored under `logs/` for easy debugging.
 - **Systemd service units** so the API and watcher start automatically on boot.
+- **Plugin architecture** allows new media sources to be added via
+  `MediaSourcePlugin` classes.
+- **Repository pattern** unifies data access for the iPod, sync queue and local
+  files.
+- **Configuration manager** loads and validates settings from JSON with
+  environment overrides.
+- **Event bus** lets components react to actions like sync progress without
+  tight coupling.
+- **Modular API routers** keep the FastAPI endpoints organised under
+  `ipod_sync/routers`.
 
 ## Dock wiring
 
@@ -259,4 +269,6 @@ Plugin developers can find usage examples in
 Unit tests run automatically on GitHub Actions for every push and pull request. The workflow installs the required Python packages from `requirements.txt` and executes `pytest`.
 
 For a more detailed overview of the repository layout and development workflow
-see [docs/developer_guide.md](docs/developer_guide.md).
+see [docs/developer_guide.md](docs/developer_guide.md). The guide now
+includes notes on the plugin system, repository pattern, configuration manager
+and event bus introduced in tasks 1 to 5.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -69,6 +69,38 @@ Set environment variables to override defaults:
 
 Log files are written to `logs/ipod_sync.log` by default.
 
+## Plugin system
+
+Media source plugins live under `ipod_sync/plugins` and subclass
+`MediaSourcePlugin`. The global `plugin_manager` discovers and loads these
+plugins at runtime so new sources can be added without changing the core
+application.
+
+## Repository pattern
+
+Data access is encapsulated by repositories in `ipod_sync/repositories`. Use
+`RepositoryFactory.get_repository()` to obtain an implementation for the iPod,
+sync queue or local library. Repositories emit events when tracks or playlists
+change.
+
+## Event bus
+
+The `ipod_sync.events` module provides a simple event bus. Emit events using
+helpers such as `emit_sync_started()` and register listeners with
+`event_bus.on(EventType, handler)`.
+
+## Configuration manager
+
+`ConfigManager` loads `config/config.json` and optional profile files, applies
+environment variable overrides and validates the result. Call
+`reload_configuration()` to refresh settings at runtime.
+
+## API routers
+
+The FastAPI server is split into router modules under `ipod_sync/routers` for
+tracks, playlists, queue management, plugins and configuration. All routes are
+mounted under `/api/v1/` by `app.py`.
+
 ## Contributing
 
 Run the test suite before submitting patches:


### PR DESCRIPTION
## Summary
- list newly completed architecture work in README
- expand developer guide with sections on the plugin system, repository pattern, event bus, configuration manager and API routers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699e31a9d88323b7017a02893f2b00